### PR TITLE
roundConserveSum in single_sample.py

### DIFF
--- a/SigProfilerAssignment/decompose_sub_routines.py
+++ b/SigProfilerAssignment/decompose_sub_routines.py
@@ -5,7 +5,7 @@ Created on Nov 16 2021
 
 @author: rvangara
 """
-import string 
+import string
 import numpy as np
 import os,sys
 #from matplot,pdblib.backends.backend_pdf import PdfPages
@@ -23,7 +23,7 @@ import sigProfilerPlotting as plot
 from SigProfilerExtractor import PlotDecomposition as sp
 from SigProfilerExtractor import plotActivity as plot_ac
 from SigProfilerExtractor import tmbplot as tmb
-import string 
+import string
 import PyPDF2
 import scipy
 #import SigProfilerAssignment as sspro
@@ -35,7 +35,7 @@ from alive_progress import alive_bar
 
 def getProcessAvg(samples, genome_build="GRCh37", cosmic_version=3.3, signature_database=None, connected_sigs = True, exome=False):
     paths = spa.__path__[0]
-    
+
     if genome_build == "GRCh37" or genome_build == "GRCh38" or genome_build == "mm9" or genome_build == "mm10" or genome_build == "rn6":
         genome_build = genome_build
     else:
@@ -47,16 +47,16 @@ def getProcessAvg(samples, genome_build="GRCh37", cosmic_version=3.3, signature_
             sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/"+genome_build+"/COSMIC_v"+str(cosmic_version)+"_SBS_"+genome_build+".txt", sep="\t", index_col=0)
         else:
             sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/"+genome_build+"/COSMIC_v"+str(cosmic_version)+"_SBS_"+genome_build+"_exome.txt", sep="\t", index_col=0)
-        signames = sigDatabase.columns   
-        
+        signames = sigDatabase.columns
+
     elif samples.shape[0]==288:
         sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/GRCh37/COSMIC_v"+str(cosmic_version)+"_SBS"+str(samples.shape[0])+"_GRCh37.txt", sep="\t", index_col=0)
         signames = sigDatabase.columns
-        
+
     elif samples.shape[0]==1536:
         sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/GRCh37/COSMIC_v"+str(cosmic_version)+"_SBS"+str(samples.shape[0])+"_GRCh37.txt", sep="\t", index_col=0)
         signames = sigDatabase.columns
-    
+
     elif samples.shape[0]==78:
         if exome==False:
             sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/"+genome_build+"/COSMIC_v"+str(cosmic_version)+"_DBS_"+genome_build+".txt", sep="\t", index_col=0)
@@ -64,12 +64,12 @@ def getProcessAvg(samples, genome_build="GRCh37", cosmic_version=3.3, signature_
             sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/"+genome_build+"/COSMIC_v"+str(cosmic_version)+"_DBS_"+genome_build+"_exome.txt", sep="\t", index_col=0)
         signames = sigDatabase.columns
         connected_sigs=False
-        
+
     elif samples.shape[0]==83:
         sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/GRCh37/COSMIC_v"+str(cosmic_version)+"_ID_GRCh37.txt", sep="\t", index_col=0)
         signames = sigDatabase.columns
         connected_sigs=False
-        
+
     elif samples.shape[0]==48:
         if cosmic_version < 3.3:
             print("The selected cosmic version is "+str(cosmic_version)+". CN signatures are available only for version 3.3. So, the cosmic version is reset to v3.3.")
@@ -84,13 +84,13 @@ def getProcessAvg(samples, genome_build="GRCh37", cosmic_version=3.3, signature_
         signames=sigDatabase.columns
         connected_sigs=False
     return sigDatabase,signames,connected_sigs
-    
+
     if signature_database != None:#pd.core.frame.DataFrame:
         print("################## USING CUSTOM SIGNATURE DATBASE ##################")
         signature_database= pd.read_csv(signature_database,sep="\t",index_col=0)
         if samples.shape[0]==signature_database.shape[0]:
             sigDatabase=signature_database
-            signames = sigDatabase.columns 
+            signames = sigDatabase.columns
             #make_decomposition_plots=False
             del signature_database
         else:
@@ -104,11 +104,11 @@ def signature_plotting_text(value, text, Type):
     name_list =[]
     total=np.sum(np.array(value))
     for i in value:
-        
-        if Type=="integer":  
+
+        if Type=="integer":
             i = int(i)
             p=round(i/total*100,1)
-            i = format(i, ',d')   
+            i = format(i, ',d')
             tail = str(i)+'/'+str(p)+'%'
             name_list.append(name+tail)
         elif Type=="float":
@@ -122,7 +122,7 @@ def make_letter_ids(idlenth = 10, mtype = "SBS96"):
     letters = list(string.ascii_uppercase)
     letters.extend([i+b for i in letters for b in letters])
     letters = letters[0:idlenth]
-    
+
     for j,l in zip(range(idlenth),letters):
         listOfSignatures.append(mtype+l)
     listOfSignatures = np.array(listOfSignatures)
@@ -133,14 +133,14 @@ def union(a, b):
     return list(set(a) | set(b))
 
 def get_indeces(a, b):
-    
-    """ 
+
+    """
     Extracts the indices multiple items in a list.
-    
+
     Parameters:
         a: list. where we want to get the index of the items.
-        b: list. the items we want to get index of. 
-    #example: 
+        b: list. the items we want to get index of.
+    #example:
     x = ['SBS1', 'SBS2', 'SBS3', 'SBS5', 'SBS8', 'SBS13', 'SBS40']
     y = ['SBS1',  'SBS5']
     get_indeces(x, y)
@@ -150,10 +150,10 @@ def get_indeces(a, b):
 
     indeces = []
     for i in b:
-        try: 
+        try:
             idx = a.index(i)
             indeces.append(idx)
-        except: 
+        except:
             next
 
     return indeces
@@ -174,36 +174,36 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
     originalProcessAvg = originalProcessAvg.reset_index()
     if not os.path.exists(directory+"/Solution_Stats"):
         os.makedirs(directory+"/Solution_Stats")
-    # open the log file for signature decomposition 
-    lognote = open(directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt", "w") 
+    # open the log file for signature decomposition
+    lognote = open(directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt", "w")
     lognote.write("############################ Signature Decomposition Details ################################\n\n\n")
     lognote.write("Context Type: {}\n".format(mtype))
     lognote.write("Genome Build: {}\n".format(genome_build))
-    
+
     # paths = spa.__path__[0]
-    
+
     # if signatures.shape[0]==96:
     #     sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/"+genome_build+"/COSMIC_v"+str(cosmic_version)+"_SBS_"+genome_build+".txt", sep="\t", index_col=0)
-    #     signames = sigDatabase.columns   
-        
+    #     signames = sigDatabase.columns
+
     # elif signatures.shape[0]==288:
     #     sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/GRCh37/COSMIC_v"+str(3.2)+"_SBS"+str(signatures.shape[0])+"_GRCh37.txt", sep="\t", index_col=0)
     #     signames = sigDatabase.columns
-        
+
     # elif signatures.shape[0]==1536:
     #     sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/"+"GRCh37"+"/COSMIC_v"+str(3.2)+"_SBS"+str(signatures.shape[0])+"_GRCh37.txt", sep="\t", index_col=0)
     #     signames = sigDatabase.columns
-    
+
     # elif signatures.shape[0]==78:
     #     sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/"+"GRCh37"+"/COSMIC_v"+str(cosmic_version)+"_DBS_"+"GRCh37"+".txt", sep="\t", index_col=0)
     #     signames = sigDatabase.columns
     #     connected_sigs=False
-        
+
     # elif signatures.shape[0]==83:
     #     sigDatabase = pd.read_csv(paths+"/data/Reference_Signatures/GRCh37/COSMIC_v"+str(cosmic_version)+"_ID_GRCh37.txt", sep="\t", index_col=0)
     #     signames = sigDatabase.columns
     #     connected_sigs=False
-        
+
     # elif signatures.shape[0]==48:
     #     sigDatabase = pd.read_csv(paths+"/data/CNV_signatures.txt", sep="\t",index_col=0)
     #     signames = sigDatabase.columns
@@ -223,40 +223,40 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
         try:
             sigDatabase = pd.read_csv(signature_database,sep='\t', index_col=0)
             #indx = sigDatabase.index()
-            if sigDatabase.shape[0]==1536: #collapse the 1596 context into 96 only for the deocmposition 
+            if sigDatabase.shape[0]==1536: #collapse the 1596 context into 96 only for the deocmposition
                 sigDatabase = sigDatabase.groupby(sigDatabase.index.str[1:8]).sum()
-                
-            elif sigDatabase.shape[0]==288 : #collapse the 288 context into 96 only for the deocmposition 
+
+            elif sigDatabase.shape[0]==288 : #collapse the 288 context into 96 only for the deocmposition
                 #sigDatabase = pd.DataFrame(processAvg, index=index)
                 sigDatabase = sigDatabase.groupby(sigDatabase.index.str[2:9]).sum()
-            
+
             if sigDatabase.shape[0]== 78 or sigDatabase.shape[0]== 83 or sigDatabase.shape[0]== 48:
                 connected_sigs=False
             lognote.write("##### Using a custom signature database for decomposition #####")
         except:
             sys.exit("Wrong format of signature database for decompose_fit, Please pass a text file of signatures in the format of COSMIC sig database")
-    
+
     sig_exclusion_list= ['SBS'+items for items in sig_exclusion_list]
     lognote.write("The following signatures are excluded: "+" ".join(str(item) for item in sig_exclusion_list))
     sigDatabase.drop(sig_exclusion_list, axis=1, inplace=True,errors='ignore')
     signames=sigDatabase.columns
-    
+
     # if type(signature_database)==pd.core.frame.DataFrame:
-        
+
     #     if signatures.shape[0]==signature_database.shape[0]:
     #         sigDatabase=signature_database
-    #         signames = sigDatabase.columns 
+    #         signames = sigDatabase.columns
     #         #make_decomposition_plots=False
-    #         del signature_database    
+    #         del signature_database
     sigDatabases = sigDatabase.reset_index()
     letters = list(string.ascii_uppercase)
     letters.extend([i+b for i in letters for b in letters])
     letters = letters[0:signatures.shape[1]]
-    
+
     # replace the probability data of the process matrix with the number of mutation
     for i in range(signatures.shape[1]):
         signatures[:, i] =  signatures[:, i]*5000      #(np.sum(exposureAvg[i, :]))
-    
+
     sigDatabase = np.array(sigDatabase)
     allsignatures = np.array([])
     newsig = list() # will create the letter based id of newsignatures
@@ -268,11 +268,11 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
     # bgsigs = (np.where(np.isin(signames.tolist(),['SBS1','SBS5']))[0]).tolist()
 
         #only for SBS96
-    if mtype == "96" or mtype=="288" or mtype=="1536":        
+    if mtype == "96" or mtype=="288" or mtype=="1536":
         bgsigs = get_indeces(list(signames), ['SBS1', 'SBS5'])
     else:
         bgsigs = []
-    
+
     # import pdb
     # pdb.set_trace()
 
@@ -282,12 +282,12 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
     activity_percentages=[]
     merger = PdfFileMerger()
 
-    
+
     for i, j in zip(range(signatures.shape[1]), denovo_signature_names):
-        
+
         # Only for context SBS96
         if signatures.shape[0]==96:
-            lognote = open(directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt", "a")  
+            lognote = open(directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt", "a")
             lognote.write("\n\n\n\n######################## Decomposing "+j+" ########################\n"  )
             lognote.close()
             if genome_build=="mm9" or genome_build=="mm10":
@@ -296,52 +296,52 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
             else:
                 check_rule_negatives = []
                 check_rule_penalty=1.0
-            
+
             # import pdb
             # pdb.set_trace()
-            
-            _, exposures,L2dist,similarity, kldiv, correlation, cosine_similarity_with_four_signatures = ss.add_remove_signatures(sigDatabase, 
-                                                                                                         signatures[:,i], 
-                                                                                                         metric="l2", 
-                                                                                                         solver="nnls", 
-                                                                                                         background_sigs = bgsigs,#[0,4], 
-                                                                                                         permanent_sigs = bgsigs,#[0,4], 
-                                                                                                         candidate_sigs="all", 
-                                                                                                         allsigids = signames, 
-                                                                                                         add_penalty = add_penalty, 
+
+            _, exposures,L2dist,similarity, kldiv, correlation, cosine_similarity_with_four_signatures = ss.add_remove_signatures(sigDatabase,
+                                                                                                         signatures[:,i],
+                                                                                                         metric="l2",
+                                                                                                         solver="nnls",
+                                                                                                         background_sigs = bgsigs,#[0,4],
+                                                                                                         permanent_sigs = bgsigs,#[0,4],
+                                                                                                         candidate_sigs="all",
+                                                                                                         allsigids = signames,
+                                                                                                         add_penalty = add_penalty,
                                                                                                          remove_penalty = remove_penalty,
-                                                                                                         check_rule_negatives = check_rule_negatives, 
-                                                                                                         checkrule_penalty = check_rule_penalty, 
-                                                                                                         directory = directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt", 
+                                                                                                         check_rule_negatives = check_rule_negatives,
+                                                                                                         checkrule_penalty = check_rule_penalty,
+                                                                                                         directory = directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt",
                                                                                                          connected_sigs=connected_sigs,
                                                                                                          verbose=False)
-    
+
         else:
-            lognote = open(directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt", "a")  
+            lognote = open(directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt", "a")
             lognote.write("\n\n\n\n######################## Decomposing "+j+" ########################\n"  )
             lognote.close()
-            
-            _, exposures,L2dist,similarity, kldiv, correlation, cosine_similarity_with_four_signatures = ss.add_remove_signatures(sigDatabase, 
-                                                                                                         signatures[:,i], 
-                                                                                                         metric="l2", 
-                                                                                                         solver="nnls", 
-                                                                                                         background_sigs = [], 
-                                                                                                         candidate_sigs="all", 
-                                                                                                         add_penalty = add_penalty, 
+
+            _, exposures,L2dist,similarity, kldiv, correlation, cosine_similarity_with_four_signatures = ss.add_remove_signatures(sigDatabase,
+                                                                                                         signatures[:,i],
+                                                                                                         metric="l2",
+                                                                                                         solver="nnls",
+                                                                                                         background_sigs = [],
+                                                                                                         candidate_sigs="all",
+                                                                                                         add_penalty = add_penalty,
                                                                                                          remove_penalty = remove_penalty,
-                                                                                                         check_rule_negatives = [], 
-                                                                                                         checkrule_penalty = [], 
-                                                                                                         directory = directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt", 
+                                                                                                         check_rule_negatives = [],
+                                                                                                         checkrule_penalty = [],
+                                                                                                         directory = directory+"/Solution_Stats/Cosmic_"+mutation_context+"_Decomposition_Log.txt",
                                                                                                          connected_sigs=connected_sigs,
                                                                                                          verbose=False)
         L1dist = np.linalg.norm(signatures[:,i]-np.dot(sigDatabase,exposures) , ord=1)/np.linalg.norm(signatures[:,i], ord=1)
         exposure_percentages = exposures[np.nonzero(exposures)]/np.sum(exposures[np.nonzero(exposures)])*100
         listofinformation = list("0"*len(np.nonzero(exposures)[0])*3)
-        
+
         count =0
         decomposed_signatures = []
         contribution_percentages = []
-        
+
         for j in np.nonzero(exposures)[0]:
             listofinformation[count*3] = signames[j]
             listofinformation[count*3+1] = round(exposure_percentages[count],2)
@@ -351,7 +351,7 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
             count+=1
         ListToTumple = tuple([mtype, letters[i]]+listofinformation+[L1dist*100]+[L2dist*100]+[kldiv]+[similarity]+[correlation])
         activity_percentages.append(contribution_percentages)
-        
+
         weights=[]
         basis_names=[]
         nonzero_exposures=exposures[np.nonzero(exposures)]
@@ -362,14 +362,14 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
             sigWeigt=str(listofinformation[info+1])+"%"
             weights.append(sigWeigt)
             basis_names.append(sigName)
-        
+
         denovo_signames=[]
         for letter in letters:
             denovo_signames.append(mutation_context+letter)
-       
-        
+
+
         sigDatabases_DF=sigDatabases
-        
+
         if mtype=="1536":
             mtype_par="1536"
         elif mtype=="288":
@@ -386,7 +386,7 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
             mtype_par="none"
         try:
             # import pdb
-            # pdb.set_trace() 
+            # pdb.set_trace()
             if mtype_par!="none" and make_decomposition_plots==True:
                 # Get the names of the columns for each dataframe
                 denovo_col_names = originalProcessAvg.columns
@@ -405,41 +405,41 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
                 #print("Decompositon Plot made for {}".format(denovo_name))
         except:
             print("The context-" + str(mtype_par) + " decomposition plots pages were not able to be generated.")
-        
-        strings ="Signature %s-%s,"+" Signature %s (%0.2f%s) &"*(len(np.nonzero(exposures)[0])-1)+" Signature %s (%0.2f%s), %0.2f,  %0.2f, %0.3f, %0.2f, %0.2f\n" 
+
+        strings ="Signature %s-%s,"+" Signature %s (%0.2f%s) &"*(len(np.nonzero(exposures)[0])-1)+" Signature %s (%0.2f%s), %0.2f,  %0.2f, %0.3f, %0.2f, %0.2f\n"
         #new_signature_thresh_hold = 0.8
-        if  similarity>new_signature_thresh_hold and cosine_similarity_with_four_signatures > new_signature_thresh_hold: ########### minimum signtatures and cosine similarity needs to be fitted to become a unique signature 
+        if  similarity>new_signature_thresh_hold and cosine_similarity_with_four_signatures > new_signature_thresh_hold: ########### minimum signtatures and cosine similarity needs to be fitted to become a unique signature
             allsignatures = np.append(allsignatures, np.nonzero(exposures))
             fh = open(directory+"/De_Novo_map_to_COSMIC_"+mutation_context+".csv", "a")
             fh.write(strings%(ListToTumple))
             fh.close()
-            
-            dictionary.update({"{}".format(mutation_context+letters[i]):decomposed_signatures}) 
-            
+
+            dictionary.update({"{}".format(mutation_context+letters[i]):decomposed_signatures})
+
         else:
             newsig.append(mutation_context+letters[i])
             newsigmatrixidx.append(i)
             fh = open(directory+"/De_Novo_map_to_COSMIC_"+mutation_context+".csv", "a")
             fh.write("Signature {}-{}, Signature {}-{}, {}, {}, {}, {}, {}\n".format(mtype, letters[i], mtype, letters[i], 0, 0, 0, 1, 1))
             fh.close()
-            dictionary.update({"{}".format(mutation_context+letters[i]):["{}".format(mutation_context+letters[i])]}) 
-            #dictionary.update({letters[i]:"Signature {}-{}, Signature {}-{}, {}\n".format(mtype, letters[i], mtype, letters[i], 1 )}) 
-    
+            dictionary.update({"{}".format(mutation_context+letters[i]):["{}".format(mutation_context+letters[i])]})
+            #dictionary.update({letters[i]:"Signature {}-{}, Signature {}-{}, {}\n".format(mtype, letters[i], mtype, letters[i], 1 )})
+
     try:
         if make_decomposition_plots and mtype_par != 'none':
-            # Write out the decomposition plots   
+            # Write out the decomposition plots
             contexts = {'96':'SBS96', '288':'SBS288', '1536':'SBS1536', '78':'DBS78', '83':'ID83', "48":"CNV"}
             merger.write(directory+"/"+contexts[mtype_par]+"_Decomposition_Plots.pdf")
     except:
         print("The context-" + str(mtype_par) + " decomposition pages were not able to be merged.")
-    
+
     different_signatures = np.unique(allsignatures)
     different_signatures=different_signatures.astype(int)
     if mtype == "96" or mtype=="288" or mtype=="1536":
         different_signatures = list(set().union(different_signatures, bgsigs))
-        different_signatures.sort()    
-      
-    
+        different_signatures.sort()
+
+
     #get the name of the signatures
     try:
         detected_signatures = signames[different_signatures]
@@ -447,26 +447,26 @@ def signature_decomposition(signatures, mtype, directory, genome_build="GRCh37",
     except:
         detected_signatures=[None]
         globalsigmats=None
-    
+
     newsigsmats=signatures[:,newsigmatrixidx]
-        
+
     #only for SBS96
-    if mtype == "96" or mtype=="288" or mtype=="1536":        
+    if mtype == "96" or mtype=="288" or mtype=="1536":
         background_sigs = get_indeces(list(detected_signatures), ['SBS1', 'SBS5'])
-        # add connected signatures   
+        # add connected signatures
         different_signatures = ss.add_connected_sigs(different_signatures, list(signames))
     #for other contexts
     else:
         background_sigs = []
-        
+
     # close the lognote
     lognote.close()
 
     # import pdb
-    # pdb.set_trace()    
+    # pdb.set_trace()
     #return values
-    return {"globalsigids": list(detected_signatures), "newsigids": newsig, "globalsigs":globalsigmats, "newsigs":newsigsmats/5000, "dictionary": dictionary, 
-            "background_sigs": background_sigs, "activity_percentages": activity_percentages} 
+    return {"globalsigids": list(detected_signatures), "newsigids": newsig, "globalsigs":globalsigmats, "newsigs":newsigsmats/5000, "dictionary": dictionary,
+            "background_sigs": background_sigs, "activity_percentages": activity_percentages}
 
 
 ############################################################################################################
@@ -487,15 +487,15 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
     solution_prefix = "_".join(solution_prefix[0:2])
     if refit_denovo_signatures==True:
             solution_prefix_refit=solution_prefix+"_refit"
-    
+
     if not os.path.exists(layer_directory+"/Signatures"):
         os.makedirs(layer_directory+"/Signatures")
     if not os.path.exists(layer_directory+"/Activities"):
         os.makedirs(layer_directory+"/Activities")
     if not os.path.exists(layer_directory+"/Solution_Stats"):
         os.makedirs(layer_directory+"/Solution_Stats")
-          
-    
+
+
     # Create the lognote file
     if refit_denovo_signatures==True:
         lognote = open(layer_directory+"/Solution_Stats/"+solution_prefix_refit+"_Signature_Assignment_log.txt", "w")
@@ -503,8 +503,8 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
         lognote = open(layer_directory+"/Solution_Stats/"+solution_prefix+"_Signature_Assignment_log.txt", "w")
     lognote.write("************************ Stepwise Description of Signature Assignment to Samples ************************")
     lognote.close()
-    
-    
+
+
     #Get the type of Signatures
     if m == 83 or m=="83":
         signature_type = "INDEL83"
@@ -514,8 +514,8 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
         connected_sigs=False
     else:
         signature_type = "SBS"+str(m)
-    
-    
+
+
     allgenomes = np.array(allgenomes)
     if (m=="96" or m=="1536" or m=="288") and (genome_build=="mm9" or genome_build=="mm10") and (collapse_to_SBS96==True):
         check_rule_negatives = [1,16]
@@ -523,7 +523,7 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
     else:
         check_rule_negatives = []
         check_rule_penalty=1.0
-    exposureAvg = np.zeros([processAvg.shape[1], allgenomes.shape[1]] )  
+    exposureAvg = np.zeros([processAvg.shape[1], allgenomes.shape[1]] )
     if cosmic_sigs==True:
         denovo_exposureAvg = denovo_exposureAvg.T
         with alive_bar(allgenomes.shape[1]) as bar:
@@ -533,153 +533,146 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
                 bar()
                 if verbose==True:
                     print("\n\n\n\n\n                                        ################ Sample "+str(r+1)+ " #################")
-                        
+
                 # Record information to lognote
                 lognote = open(layer_directory+"/Solution_Stats/"+solution_prefix+"_Signature_Assignment_log.txt", "a")
-                lognote.write("\n\n\n\n\n                    ################ Sample "+str(r+1)+ " #################\n") 
-                
+                lognote.write("\n\n\n\n\n                    ################ Sample "+str(r+1)+ " #################\n")
+
                 sample_exposure = np.array(denovo_exposureAvg.iloc[:,r])
-                
+
                 init_sig_idx = np.nonzero(sample_exposure)[0]
                 init_sigs = denovo_exposureAvg.index[init_sig_idx]
-                
-                
+
+
                 init_decomposed_sigs = []
                 for de_novo_sig in init_sigs:
-                    
+
                     init_decomposed_sigs = union(init_decomposed_sigs, list(attribution[de_novo_sig]))
-                    
-                #print(init_decomposed_sigs) 
+
+                #print(init_decomposed_sigs)
                 init_decomposed_sigs_idx = get_indeces(allsigids, init_decomposed_sigs)
                 init_decomposed_sigs_idx.sort()
                 init_decomposed_sigs_idx = list(set().union(init_decomposed_sigs_idx, background_sigs))
                 #print(init_decomposed_sigs_idx)
-                
+
                 # get the indices of the background sigs in the initial signatures
                 background_sig_idx = get_indeces(init_decomposed_sigs_idx, background_sigs)
-                
-                
+
+
                 fit_signatures = processAvg[:,init_decomposed_sigs_idx]
                 #fit signatures
                 newExposure, newSimilarity = ss.fit_signatures(fit_signatures, allgenomes[:,r])
-                
-                
+
+
                 #create the exposureAvg vector
                 #print(init_decomposed_sigs_idx)
                 #print(newExposure)
                 for nonzero_idx, nozero_exp in zip(init_decomposed_sigs_idx, newExposure):
                     exposureAvg[nonzero_idx, r] = nozero_exp
-                
-                
+
+
                 if pcawg_rule==True:
                     maxmutation=np.sum(allgenomes[:,r])
                     exposureAvg[:, r], remove_distance, _ = ss.remove_all_single_signatures(processAvg, exposureAvg[:, r], allgenomes[:,r], metric="l2", verbose = False, cutoff=0.02)
-                    # get the maximum value of the new Exposure
-                    maxcoef = max(list(exposureAvg[:, r]))
-                    idxmaxcoef = list(exposureAvg[:, r]).index(maxcoef)
-                
-                    exposureAvg[:, r] = np.round(exposureAvg[:, r])
-                
+                    
+                    exposureAvg[:, r] = ss.roundConserveSum(exposureAvg[:, r])
                     # We may need to tweak the maximum value of the new exposure to keep the total number of mutation equal to the original mutations in a genome
-                    if np.sum(exposureAvg[:, r])!=maxmutation:
-                        exposureAvg[:, r][idxmaxcoef] = round(exposureAvg[:, r][idxmaxcoef])+maxmutation-sum(exposureAvg[:, r])
-                    #print(exposureAvg[:, r]) 
-                    #print("\n")
-                        
+                    if np.sum(exposureAvg[:, r])!=round(maxmutation): raise ValueError("Mutation count not conserved")
+
                 else:
                     if verbose==True:
-                        print("############################# Initial Composition #################################### ") 
-                        print(pd.DataFrame(exposureAvg[:, r],  index=allsigids).T)   
-                        print("L2%: ", newSimilarity)  
-                        
+                        print("############################# Initial Composition #################################### ")
+                        print(pd.DataFrame(exposureAvg[:, r],  index=allsigids).T)
+                        print("L2%: ", newSimilarity)
+
                     lognote.write("############################# Initial Composition ####################################\n")
                     exposures = pd.DataFrame(exposureAvg[:, r],  index=allsigids).T
-                    lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]])) 
+                    lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]]))
                     lognote.write("L2 Error %: {}\nCosine Similarity: {}\n".format(round(newSimilarity,2), round(cos_sim(allgenomes[:,r], np.dot(processAvg, exposureAvg[:, r] )),2)))
-                    #remove signatures 
+                    #remove signatures
                     exposureAvg[:,r],L2dist,cosine_sim = ss.remove_all_single_signatures(processAvg, exposureAvg[:, r], allgenomes[:,r], metric="l2", \
                             solver = "nnls", cutoff=initial_remove_penalty, background_sigs= [], verbose=False)
                     if verbose==True:
                         print("############################## Composition After Initial Remove ############################### ")
-                        print(pd.DataFrame(exposureAvg[:, r],  index=allsigids).T)  
+                        print(pd.DataFrame(exposureAvg[:, r],  index=allsigids).T)
                         print("L2%: ", L2dist)
                     lognote.write("############################## Composition After Initial Remove ###############################\n")
                     exposures = pd.DataFrame(exposureAvg[:, r],  index=allsigids).T
-                    lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]])) 
+                    lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]]))
                     lognote.write("L2 Error %: {}\nCosine Similarity: {}\n".format(round(L2dist,2), round(cosine_sim,2)))
                     lognote.write("\n############################## Performing Add-Remove Step ##############################\n")
                     #Close the Lognote file
                     lognote.close()
-                    
+
                     init_add_sig_idx = list(set().union(list(np.nonzero(exposureAvg[:, r])[0]), background_sigs))
                     #print(init_add_sig_idx)
-                    
-                    
+
+
                     #get the background_sig_idx for the add_remove function only for the decomposed solution:
-                    if background_sigs != 0:  # in the decomposed solution only 
+                    if background_sigs != 0:  # in the decomposed solution only
                         background_sig_idx = get_indeces(allsigids, ["SBS1", "SBS5"])
-                
+
                     # if the there is no other signatures to be added on top the existing signatures
                     try:
-                        _, exposureAvg[:, r],L2dist,similarity, kldiv, correlation, cosine_similarity_with_four_signatures = ss.add_remove_signatures(processAvg, 
-                                                                                                        allgenomes[:,r], 
-                                                                                                        metric="l2", 
-                                                                                                        solver="nnls", 
-                                                                                                        background_sigs = init_add_sig_idx, 
-                                                                                                        permanent_sigs = background_sig_idx, 
-                                                                                                        candidate_sigs="all", 
-                                                                                                        allsigids = allsigids, 
-                                                                                                        add_penalty = add_penalty, 
+                        _, exposureAvg[:, r],L2dist,similarity, kldiv, correlation, cosine_similarity_with_four_signatures = ss.add_remove_signatures(processAvg,
+                                                                                                        allgenomes[:,r],
+                                                                                                        metric="l2",
+                                                                                                        solver="nnls",
+                                                                                                        background_sigs = init_add_sig_idx,
+                                                                                                        permanent_sigs = background_sig_idx,
+                                                                                                        candidate_sigs="all",
+                                                                                                        allsigids = allsigids,
+                                                                                                        add_penalty = add_penalty,
                                                                                                         remove_penalty=remove_penalty,
-                                                                                                        check_rule_negatives = check_rule_negatives, 
-                                                                                                        checkrule_penalty = check_rule_penalty, 
+                                                                                                        check_rule_negatives = check_rule_negatives,
+                                                                                                        checkrule_penalty = check_rule_penalty,
                                                                                                         connected_sigs=connected_sigs,
-                                                                                                        directory = layer_directory+"/Solution_Stats/"+solution_prefix+"_Signature_Assignment_log.txt", 
+                                                                                                        directory = layer_directory+"/Solution_Stats/"+solution_prefix+"_Signature_Assignment_log.txt",
                                                                                                         verbose=False)
-                        
+
                         if verbose==True:
-                            print("####################################### Composition After Add-Remove #######################################\n") 
+                            print("####################################### Composition After Add-Remove #######################################\n")
                             print(exposureAvg[:, r])
                             print("L2%: ", L2dist)
                         # Recond the information in the log file
                         lognote = open(layer_directory+"/Solution_Stats/"+solution_prefix+"_Signature_Assignment_log.txt", "a")
                         lognote.write("####################################### Composition After Add-Remove #######################################\n")
                         exposures = pd.DataFrame(exposureAvg[:, r],  index=allsigids).T
-                        lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]])) 
+                        lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]]))
                         lognote.write("L2 Error %: {}\nCosine Similarity: {}\n".format(round(L2dist,2), round(similarity,2)))
                         lognote.close()
                     except:
                         pass
-            
-    else:   
-        # when refilt de_novo_signatures 
+
+    else:
+        # when refilt de_novo_signatures
         refit_denovo_signatures_old = False
         if refit_denovo_signatures_old==True:
             exposureAvg=denovo_exposureAvg
             for g in range(allgenomes.shape[1]):
                 print("Analyzing Sample => " , str(g+1))
-                
+
                 # Record information to lognote
                 lognote = open(layer_directory+"/Solution_Stats/"+solution_prefix_refit+"_Signature_Assignment_log.txt", "a")
                 lognote.write("\n\n\n\n\n                    ################ Sample "+str(g+1)+ " #################\n")
 
                 lognote.write("############################# Initial Composition ####################################\n")
                 exposures = pd.DataFrame(exposureAvg[:, g],  index=allsigids).T
-                lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]])) 
-                
-                #remove signatures 
+                lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]]))
+
+                #remove signatures
                 exposureAvg[:,g],L2dist,cosine_sim = ss.remove_all_single_signatures(processAvg, exposureAvg[:, g], allgenomes[:,g], metric="l2", \
                            solver = "nnls", cutoff=de_novo_fit_penalty, background_sigs= [], verbose=False)
                 if verbose==True:
                     print("############################## Composition After Remove ############################### ")
-                    print(pd.DataFrame(exposureAvg[:, g],  index=allsigids).T)  
+                    print(pd.DataFrame(exposureAvg[:, g],  index=allsigids).T)
                     print("L2%: ", L2dist)
                 lognote.write("############################## Composition After  Remove ###############################\n")
                 exposures = pd.DataFrame(exposureAvg[:, g],  index=allsigids).T
-                lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]])) 
+                lognote.write("{}\n".format(exposures.iloc[:,exposures.to_numpy().nonzero()[1]]))
                 lognote.write("L2 Error %: {}\nCosine Similarity: {}\n".format(round(L2dist,2), round(cosine_sim,2)))
                 lognote.close()
-                
+
         # when use the exposures from the initial NMF
         else:
             exposureAvg=denovo_exposureAvg
@@ -688,7 +681,7 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
     processes = processAvg.set_index(index)
     processes.columns = allsigids
     processes = processes.rename_axis("MutationType", axis="columns")
-    processes.to_csv(layer_directory+"/Signatures"+"/"+solution_prefix+"_"+"Signatures.txt", "\t", float_format='%.8f',index_label=[processes.columns.name]) 
+    processes.to_csv(layer_directory+"/Signatures"+"/"+solution_prefix+"_"+"Signatures.txt", "\t", float_format='%.8f',index_label=[processes.columns.name])
     exposureAvg = pd.DataFrame(exposureAvg.astype(int))
     allsigids = np.array(allsigids)
     exposures = exposureAvg.set_index(allsigids)
@@ -696,9 +689,9 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
     exposures = exposures.T
     exposures = exposures.rename_axis("Samples", axis="columns")
     if refit_denovo_signatures==True:
-        exposures.to_csv(layer_directory+"/Activities"+"/"+solution_prefix+"_"+"Activities_refit.txt", "\t", index_label=[exposures.columns.name]) 
+        exposures.to_csv(layer_directory+"/Activities"+"/"+solution_prefix+"_"+"Activities_refit.txt", "\t", index_label=[exposures.columns.name])
     else:
-        exposures.to_csv(layer_directory+"/Activities"+"/"+solution_prefix+"_"+"Activities.txt", "\t", index_label=[exposures.columns.name]) 
+        exposures.to_csv(layer_directory+"/Activities"+"/"+solution_prefix+"_"+"Activities.txt", "\t", index_label=[exposures.columns.name])
 
     #plt tmb
     tmb_exposures = pd.melt(exposures)
@@ -708,24 +701,24 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
         else:
             tmb.plotTMB(tmb_exposures, scale=sequence, Yrange="adapt", output= layer_directory+"/Activities"+"/"+solution_prefix+"_"+"TMB_plot.pdf")
         del tmb_exposures
-        
+
     #plot activities
     if make_plots ==True:
         if refit_denovo_signatures==True:
             plot_ac.plotActivity(layer_directory+"/Activities"+"/"+solution_prefix+"_"+"Activities_refit.txt", output_file = layer_directory+"/Activities/"+solution_prefix+"_"+"Activity_Plots_refit.pdf", bin_size = 50, log = False)
         else:
             plot_ac.plotActivity(layer_directory+"/Activities"+"/"+solution_prefix+"_"+"Activities.txt", output_file = layer_directory+"/Activities/"+solution_prefix+"_"+"Activity_Plots.pdf", bin_size = 50, log = False)
-    
+
     # Calcutlate the similarity matrices
     est_genomes = np.dot(processAvg, exposureAvg)
     all_similarities, cosine_similarities = calculate_similarities(allgenomes, est_genomes, allcolnames)
     all_similarities.iloc[:,[3,5]] = all_similarities.iloc[:,[3,5]].astype(str) + '%'
-    
+
     if refit_denovo_signatures==True:
         all_similarities.to_csv(layer_directory+"/Solution_Stats/"+solution_prefix+"_Samples_Stats_refit.txt", sep="\t")
     else:
         all_similarities.to_csv(layer_directory+"/Solution_Stats/"+solution_prefix+"_Samples_Stats.txt", sep="\t")
-    
+
     #if cosmic_sigs==False:
     if refit_denovo_signatures ==True:
         try:
@@ -733,15 +726,15 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
             processSTE = process_std_error.set_index(index)
             processSTE.columns = allsigids
             processSTE = processSTE.rename_axis("MutationType", axis="columns")
-            processSTE.to_csv(layer_directory+"/Signatures"+"/"+solution_prefix+"_"+"Signatures_SEM_Error.txt", "\t", float_format='%.2E', index_label=[processes.columns.name]) 
+            processSTE.to_csv(layer_directory+"/Signatures"+"/"+solution_prefix+"_"+"Signatures_SEM_Error.txt", "\t", float_format='%.2E', index_label=[processes.columns.name])
         except:
             pass
     #if cosmic_sigs==False:
     if refit_denovo_signatures ==True:
-        try: 
+        try:
             signature_stats = signature_stats.set_index(allsigids)
             signature_stats = signature_stats.rename_axis("Signatures", axis="columns")
-            signature_stats.to_csv(layer_directory+"/Solution_Stats"+"/"+solution_prefix+"_"+"Signatures_Stats.txt", "\t", index_label=[exposures.columns.name]) 
+            signature_stats.to_csv(layer_directory+"/Solution_Stats"+"/"+solution_prefix+"_"+"Signatures_Stats.txt", "\t", index_label=[exposures.columns.name])
             signature_total_mutations = np.sum(exposureAvg, axis =1).astype(int)
             signature_total_mutations = signature_plotting_text(signature_total_mutations, "Sig. Mutations", "integer")
         except:
@@ -750,11 +743,11 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
         signature_total_mutations = np.sum(exposureAvg, axis =1).astype(int)
         signature_total_mutations = signature_plotting_text(signature_total_mutations, "Sig. Mutations", "integer")
         if (m == "1536" or m=="288") and collapse_to_SBS96==True: # collapse the 1536 to 96
-            m = "96"  
+            m = "96"
     if make_plots == True:
     ########################################### PLOT THE SIGNATURES ################################################
         if m=="DINUC" or m=="78":
-            plot.plotDBS(layer_directory+"/Signatures/"+solution_prefix+"_"+"Signatures.txt", layer_directory+"/Signatures"+"/" , solution_prefix, "78", True, custom_text_upper= signature_stabilities, custom_text_middle = signature_total_mutations )        
+            plot.plotDBS(layer_directory+"/Signatures/"+solution_prefix+"_"+"Signatures.txt", layer_directory+"/Signatures"+"/" , solution_prefix, "78", True, custom_text_upper= signature_stabilities, custom_text_middle = signature_total_mutations )
         elif m=="INDEL" or m=="83":
             plot.plotID(layer_directory+"/Signatures/"+solution_prefix+"_"+"Signatures.txt", layer_directory+"/Signatures"+"/" , solution_prefix, "94", True, custom_text_upper= signature_stabilities, custom_text_middle = signature_total_mutations )
         elif m=="CNV" or m=="48":
@@ -771,29 +764,29 @@ def make_final_solution(processAvg, allgenomes, allsigids, layer_directory, m, i
             plot.plotSBS(layer_directory+"/Signatures/"+solution_prefix+"_"+"Signatures.txt", layer_directory+"/Signatures"+"/", solution_prefix, m, True, custom_text_upper= signature_stabilities, custom_text_middle = signature_total_mutations )
         else:
             custom_signatures_plot(processes, layer_directory+"/Signatures")
-    
+
     probability = probabilities(processAvg, exposureAvg, index, allsigids, allcolnames)
     probability=probability.set_index("Sample Names" )
-    
+
     if cosmic_sigs==False:
-        
+
         if refit_denovo_signatures==True:
-            probability.to_csv(layer_directory+"/Activities"+"/"+"De_Novo_Mutation_Probabilities_refit.txt", "\t") 
+            probability.to_csv(layer_directory+"/Activities"+"/"+"De_Novo_Mutation_Probabilities_refit.txt", "\t")
         else:
-            probability.to_csv(layer_directory+"/Activities"+"/"+"De_Novo_Mutation_Probabilities.txt", "\t") 
+            probability.to_csv(layer_directory+"/Activities"+"/"+"De_Novo_Mutation_Probabilities.txt", "\t")
     if cosmic_sigs==True:
-        probability.to_csv(layer_directory+"/Activities"+"/"+"Decomposed_Mutation_Probabilities.txt", "\t") 
-    
+        probability.to_csv(layer_directory+"/Activities"+"/"+"Decomposed_Mutation_Probabilities.txt", "\t")
+
 
     return exposures
 ################################################################### FUNCTION ONE ###################################################################
 #function to calculate multiple similarities/distances
 def calculate_similarities(genomes, est_genomes, sample_names=False):
     from numpy import inf
-    
+
     if  sample_names is False:
         sample_names = ["None"]*genomes.shape[1]
-        
+
     cosine_similarity_list = []
     kl_divergence_list = []
     correlation_list=[]
@@ -802,7 +795,7 @@ def calculate_similarities(genomes, est_genomes, sample_names=False):
     total_mutations_list = []
     relative_l1_list = []
     relative_l2_list = []
-    
+
     for i in range(genomes.shape[1]):
         p_i = genomes[:,i]
         q_i = est_genomes[:, i]
@@ -833,62 +826,62 @@ def calculate_similarities(genomes, est_genomes, sample_names=False):
 ################################################################### FUNCTION ONE ###################################################################
 #function to calculate the cosine similarity
 def cos_sim(a, b):
-      
-    
-    """Takes 2 vectors a, b and returns the cosine similarity according 
+
+
+    """Takes 2 vectors a, b and returns the cosine similarity according
     to the definition of the dot product
-    
-    Dependencies: 
-    *Requires numpy library. 
+
+    Dependencies:
+    *Requires numpy library.
     *Does not require any custom function (constructed by me)
-    
+
     Required by:
     * pairwise_cluster_raw
     	"""
     if np.sum(a)==0 or np.sum(b) == 0:
-        return 0.0      
+        return 0.0
     dot_product = np.dot(a, b)
     norm_a = np.linalg.norm(a)
     norm_b = np.linalg.norm(b)
     return dot_product / (norm_a * norm_b)
 
 def cor_sim(a, b):
-      
-    
-    """Takes 2 vectors a, b and returns the corrilation similarity according 
+
+
+    """Takes 2 vectors a, b and returns the corrilation similarity according
     to the definition of the dot product
-    
-    Dependencies: 
-    *Requires numpy library. 
+
+    Dependencies:
+    *Requires numpy library.
     *Does not require any custom function (constructed by me)
-    
+
     Required by:
     * pairwise_cluster_raw
     	"""
     if np.sum(a)==0 or np.sum(b) == 0:
-        return 0.0      
+        return 0.0
     corr =1-cor(a, b)
     return corr
 
 ################################################### Generation of probabilities for each processes given to A mutation type ############################################
-def probabilities(W, H, index, allsigids, allcolnames):  
-    
-    # setting up the indices 
+def probabilities(W, H, index, allsigids, allcolnames):
+
+    # setting up the indices
     rows = index
     cols = allcolnames
     sigs = allsigids
-    
+
     W = np.array(W)
     H= np.array(H)
-    # rebuild the original matrix from the estimated W and H 
+    # rebuild the original matrix from the estimated W and H
     genomes = np.dot(W,H)
-    
-    
+
+
     result = 0
     for i in range(H.shape[1]): #here H.shape is the number of sample
-        
+
         M = genomes[:,i][np.newaxis]
-        probs = W*H[:,i]/M.T        
+        probs = W*H[:,i]/M.T
         probs = pd.DataFrame(probs)
         probs.columns = sigs
         col1 = [cols[i]]*len(rows)
@@ -898,8 +891,8 @@ def probabilities(W, H, index, allsigids, allcolnames):
             result = pd.concat([result, probs], axis=0)
         else:
             result = probs
-    
-        
+
+
     return result
 
 def custom_signatures_plot(signatures, output):
@@ -921,7 +914,7 @@ def custom_signatures_plot(signatures, output):
             plt.xticks([])
             plt.xlabel("Mutation Types")
             plt.ylabel("Probabilities")
-            pdf.attach_note("signature plots")  
+            pdf.attach_note("signature plots")
             pdf.savefig()
             plt.close()
 
@@ -931,7 +924,7 @@ def merge_pdf(input_folder, output_file):
         #print(filename)
         if filename.endswith('.pdf'):
             pdf2merge.append(filename)
-            
+
     pdf2merge.sort()
     pdfWriter = PyPDF2.PdfFileWriter()
     for filename in pdf2merge:
@@ -940,7 +933,7 @@ def merge_pdf(input_folder, output_file):
         for pageNum in range(pdfReader.numPages):
             pageObj = pdfReader.getPage(pageNum)
             pdfWriter.addPage(pageObj)
-            
+
     pdfOutput = open(output_file+'.pdf', 'wb')
     pdfWriter.write(pdfOutput)
     #Outputting the PDF

--- a/SigProfilerAssignment/single_sample.py
+++ b/SigProfilerAssignment/single_sample.py
@@ -103,14 +103,17 @@ def get_changed_background_sig_idx(exposures, background_sigs):
 # Round counts conserving integer total
 def roundConserveSum(x):
 
+    # Convert to array
+    x_in = np.array(x)
+
     # Total to be conserved
-    total = np.round(np.sum(x))
+    total = np.round(np.sum(x_in))
 
     # Round to nearest integer above
-    x_out = np.ceil(x)
+    x_out = np.ceil(x_in+1e-10)
 
     # Order integer residuals
-    order = np.argsort(x-x_out)
+    order = np.argsort(x_in-x_out)
 
     # Take one off first n residuals to correct total
     x_out[order[:int(np.sum(x_out)-total+1e-10)]] -= 1

--- a/SigProfilerAssignment/single_sample.py
+++ b/SigProfilerAssignment/single_sample.py
@@ -12,7 +12,7 @@ from scipy.optimize import minimize
 #from SigProfilerExtractor import subroutines as sub
 from SigProfilerAssignment import decompose_sub_routines as sub
 import scipy.stats
-import copy 
+import copy
 import os
 
 #############################################################################################################
@@ -21,38 +21,38 @@ import os
 ################################################################### FUNCTION ONE ###################################################################
 #function to calculate the cosine similarity
 def cos_sim(a, b):
-      
-    
-    """Takes 2 vectors a, b and returns the cosine similarity according 
+
+
+    """Takes 2 vectors a, b and returns the cosine similarity according
     to the definition of the dot product
-    
-    Dependencies: 
-    *Requires numpy library. 
+
+    Dependencies:
+    *Requires numpy library.
     *Does not require any custom function (constructed by me)
-    
+
     Required by:
     * pairwise_cluster_raw
     	"""
     if np.sum(a)==0 or np.sum(b) == 0:
-        return 0.0      
+        return 0.0
     dot_product = np.dot(a, b)
     norm_a = np.linalg.norm(a)
     norm_b = np.linalg.norm(b)
     return dot_product / (norm_a * norm_b)
 
-def add_connected_sigs(background_sigs, allsigids): 
+def add_connected_sigs(background_sigs, allsigids):
     connected_sigs = [["SBS2", "SBS13"],
                   ["SBS7a", "SBS7b", "SBS7c", "SBS7d"],
                   ["SBS10a", "SBS10b"],
                   ["SBS17a", "SBS17b"]]
-    
+
     backround_sig_names = sub.get_items_from_index(allsigids,background_sigs )
     connect_the_sigs = []
     for i in range(len(connected_sigs)):
         if len(set(connected_sigs[i]).intersection(set(backround_sig_names)))>0:
             connect_the_sigs = connect_the_sigs+connected_sigs[i]
-    
-    backround_sig_names = list(set(backround_sig_names).union(set(connect_the_sigs)))    
+
+    backround_sig_names = list(set(backround_sig_names).union(set(connect_the_sigs)))
     background_sigs = sub.get_indeces(allsigids, backround_sig_names)
     background_sigs.sort()
     return background_sigs
@@ -79,80 +79,87 @@ def create_bounds(idxOfZeros, samples, numOfSignatures):
     total = np.sum(samples)
     b = (0.0, float(total))
     lst =[b]*numOfSignatures
-    
+
     for i in idxOfZeros:
-        lst[i] = (0.0, 0.0) 
-    
-    return lst 
+        lst[i] = (0.0, 0.0)
+
+    return lst
 
 # required for removing signatures with background
 def get_changed_background_sig_idx(exposures, background_sigs):
-    
+
     background_sigs_values = sub.get_items_from_index(exposures,background_sigs)
     temp_exposures = exposures[:]
     temp_exposures[:] = (value for value in temp_exposures if value != 0)
-    
+
     # remove the background signatures with zero values
     background_sigs[:] = (value for value in background_sigs_values if value != 0)
-    
-    # get the new indices of the background signatures 
+
+    # get the new indices of the background signatures
     background_sigs = sub.get_indeces(temp_exposures, background_sigs_values)
-    
+
     return background_sigs
 
+# Round counts conserving integer total
+def roundConserveSum(x):
 
-# Fit signatures 
+    # Total to be conserved
+    total = np.round(np.sum(x))
+
+    # Round to nearest integer above
+    x_out = np.ceil(x)
+
+    # Order integer residuals
+    order = np.argsort(x-x_out)
+
+    # Take one off first n residuals to correct total
+    x_out[order[:int(np.sum(x_out)-total+1e-10)]] -= 1
+
+    return x_out
+
+# Fit signatures
 def fit_signatures(W, genome, metric="l2"):
     genome = np.array(genome)
     maxmutation = round(np.sum(genome))
-     
-    
-    
+
+
+
     #initialize the guess
     x0 = np.random.rand(W.shape[1], 1)*maxmutation
     x0= x0/np.sum(x0)*maxmutation
-    
+
     #the optimization step
     #set the bounds and constraints
-    #bnds = create_bounds([], genome, W.shape[1]) 
+    #bnds = create_bounds([], genome, W.shape[1])
     #cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genome]}
-    
-    
+
+
     #sol = scipy.optimize.minimize(parameterized_objective2_custom, x0, args=(W, genome),  bounds=bnds, constraints =cons1, tol=1e-30)
     #solution = sol.x
-    
-    
-    ### using NNLS algorithm 
+
+
+    ### using NNLS algorithm
     reg = nnls(W,genome)
     weights = reg[0]
     est_genome = np.dot(W, weights)
     normalised_weights = weights/sum(weights)
     solution = normalised_weights*sum(genome)
-    
-    
-    
+
+
+
     #print(W1)
     #convert the newExposure vector into list type structure
     newExposure = list(solution)
-    
-    
-    # get the maximum value of the new Exposure
-    maxcoef = max(newExposure)
-    idxmaxcoef = newExposure.index(maxcoef)
-    
-    newExposure = np.round(newExposure)
-    
+
+    newExposure = roundConserveSum(newExposure)
     # We may need to tweak the maximum value of the new exposure to keep the total number of mutation equal to the original mutations in a genome
-    if np.sum(newExposure)!=maxmutation:
-        newExposure[idxmaxcoef] = round(newExposure[idxmaxcoef])+maxmutation-sum(newExposure)
-     
-    
-    
+    if np.sum(newExposure)!=maxmutation: raise ValueError("Mutation count not conserved")
+
     if metric=="cosine":
         newSimilarity = cos_sim(genome, est_genome)
     else:
         newSimilarity = np.linalg.norm(genome-est_genome , ord=2)/np.linalg.norm(genome, ord=2)
-    
+
     return (newExposure, newSimilarity)
 
 # to do the calculation, we need: W, samples(one column), H for the specific sample, tolerence
@@ -161,99 +168,92 @@ def fit_signatures_pool(total_genome, W, index, metric="l2"):
     genome = total_genome[:,index]
     genome = np.array(genome)
     maxmutation = round(np.sum(genome))
-     
-    
-    
+
+
+
     #initialize the guess
     x0 = np.random.rand(W.shape[1], 1)*maxmutation
     x0= x0/np.sum(x0)*maxmutation
-    
+
     #the optimization step
     #set the bounds and constraints
-    #bnds = create_bounds([], genome, W.shape[1]) 
+    #bnds = create_bounds([], genome, W.shape[1])
     #cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genome]}
-    
-    
+
+
     #sol = scipy.optimize.minimize(parameterized_objective2_custom, x0, args=(W, genome),  bounds=bnds, constraints =cons1, tol=1e-30)
     #solution = sol.x
-    
-    
-    ### using NNLS algorithm 
+
+
+    ### using NNLS algorithm
     reg = nnls(W,genome)
     weights = reg[0]
     est_genome = np.dot(W, weights)
     normalised_weights = weights/sum(weights)
     solution = normalised_weights*sum(genome)
-    
+
     #print(W1)
     #convert the newExposure vector into list type structure
     newExposure = list(solution)
-    
-    
-    # get the maximum value of the new Exposure
-    maxcoef = max(newExposure)
-    idxmaxcoef = newExposure.index(maxcoef)
-    
-    newExposure = np.round(newExposure)
-    
+
+    newExposure = roundConserveSum(newExposure)
     # We may need to tweak the maximum value of the new exposure to keep the total number of mutation equal to the original mutations in a genome
-    if np.sum(newExposure)!=maxmutation:
-        newExposure[idxmaxcoef] = round(newExposure[idxmaxcoef])+maxmutation-sum(newExposure)
-     
-    
-    
+    if np.sum(newExposure)!=maxmutation: raise ValueError("Mutation count not conserved")
+
+
+
     if metric=="cosine":
         newSimilarity = cos_sim(genome, est_genome)
     else:
         newSimilarity = np.linalg.norm(genome-est_genome , ord=2)/np.linalg.norm(genome, ord=2)
-    
+
     return (newExposure, newSimilarity)
 
 
 def add_signatures(W, genome, cutoff=0.05, presentSignatures=[], toBeAdded="all", metric="l2", solver="nnls", check_rule_negatives=[], check_rule_penalty=1.0, verbose = False):
-     # This function takes an array of signature and a single genome as input, returns a dictionray of cosine similarity, exposures and presence 
+     # This function takes an array of signature and a single genome as input, returns a dictionray of cosine similarity, exposures and presence
      # of signatures according to the indices of the original signature array
-    
+
     if toBeAdded == "all":
         notToBeAdded=[]
-    else:               
+    else:
         #print(len(list(range(W.shape[1]))))
         #print(len(toBeAdded))
         notToBeAdded = list(set(list(range(W.shape[1])))-set(toBeAdded)) # get the indices of the signatures to be excluded
-        
+
         #print(len(notToBeAdded))
     originalSimilarity = np.inf # it can be also written as oldsimilarity. wanted to put a big number
     maxmutation = round(np.sum(genome))
-    init_listed_idx = presentSignatures 
-    
+    init_listed_idx = presentSignatures
+
     init_nonlisted_idx = list(set(list(range(W.shape[1])))-set(init_listed_idx)-set(notToBeAdded))
-    
+
     finalRecord = [["similarity place-holder" ], ["newExposure place-holder"], ["signatures place-holder"]] #for recording the cosine difference, similarity, the new exposure and the index of the best signauture
-    
+
     # get the initial original similarity if some signatures are already given to be present
     if len(init_listed_idx)!=0:
-        
+
         loop_liststed_idx=init_listed_idx
         loop_liststed_idx.sort()
-        
+
         W1 = W[:,loop_liststed_idx]
-       
+
         #print (W1.shape)
         #initialize the guess
         x0 = np.random.rand(W1.shape[1], 1)*maxmutation
         x0= x0/np.sum(x0)*maxmutation
-        
+
         #set the bounds and constraints
-        bnds = create_bounds([], genome, W1.shape[1]) 
-        cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genome]} 
-        
+        bnds = create_bounds([], genome, W1.shape[1])
+        cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genome]}
+
         #the optimization step
         if solver == "slsqp":
             sol = minimize(parameterized_objective2_custom, x0, args=(W1, genome),  bounds=bnds, constraints =cons1, tol=1e-30)
             newExposure = list(sol.x)
             est_genome = np.dot(W1, np.array(newExposure))
         if solver == "nnls":
-        ### using NNLS algorithm        
+        ### using NNLS algorithm
             reg = nnls(W1, genome[:,0])
             weights = reg[0]
             est_genome = np.dot(W1, weights)
@@ -262,40 +262,33 @@ def add_signatures(W, genome, cutoff=0.05, presentSignatures=[], toBeAdded="all"
             newExposure = list(solution)
         #print(W1)
         #convert the newExposure vector into list type structure
-        
+
         #newExposure = list(solution) #for nnls
-                           
-                          
-        # get the maximum value of the new Exposure
-        maxcoef = max(newExposure)
-        idxmaxcoef = newExposure.index(maxcoef)
-        
-        newExposure = np.round(newExposure)
-        
+
+        newExposure = roundConserveSum(newExposure)
         # We may need to tweak the maximum value of the new exposure to keep the total number of mutation equal to the original mutations in a genome
-        if np.sum(newExposure)!=maxmutation:
-            newExposure[idxmaxcoef] = round(newExposure[idxmaxcoef])+maxmutation-sum(newExposure)
-         
-        
+        if np.sum(newExposure)!=maxmutation: raise ValueError("Mutation count not conserved")
+
+
         if metric=="cosine":
             originalSimilarity = 1-cos_sim(genome[:,0], est_genome )
-        elif metric=="l2":    
+        elif metric=="l2":
             originalSimilarity = np.linalg.norm(genome[:,0]-est_genome , ord=2)/np.linalg.norm(genome[:,0], ord=2)
-        
-            
+
+
         finalRecord = [originalSimilarity, newExposure, init_listed_idx]
-        
-        
+
+
     while True:
-        
+
         bestDifference = -np.inf  #### wanted to put a big initila number
         bestSimilarity = np.inf #### actually bestdistance
         loopRecord = [["newExposure place-holder"], ["signatures place-holder"], ["best loop signature place-holder"]]
-        
+
         for sig in init_nonlisted_idx:
-            
-            
-            
+
+
+
             if len(init_listed_idx)!=0:
                 loop_liststed_idx=init_listed_idx+[sig]
                 loop_liststed_idx.sort()
@@ -305,21 +298,21 @@ def add_signatures(W, genome, cutoff=0.05, presentSignatures=[], toBeAdded="all"
                 #initialize the guess
                 x0 = np.random.rand(W1.shape[1], 1)*maxmutation
                 x0= x0/np.sum(x0)*maxmutation
-                
+
                 #set the bounds and constraints
-                bnds = create_bounds([], genome, W1.shape[1]) 
-                cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genome]} 
-            # for the first time addintion  
+                bnds = create_bounds([], genome, W1.shape[1])
+                cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genome]}
+            # for the first time addintion
             else:
                 W1 = W[:,sig][:,np.newaxis]
-                #print (W1.shape)        
+                #print (W1.shape)
                 #initialize the guess
-                x0 = np.ones((1,1))*maxmutation    
-            
+                x0 = np.ones((1,1))*maxmutation
+
                 #set the bounds and constraints
-                bnds = create_bounds([], genome, 1) 
-                cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genome]} 
-            
+                bnds = create_bounds([], genome, 1)
+                cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genome]}
+
             if solver == "slsqp":
                 #the optimization step
                 sol = minimize(parameterized_objective2_custom, x0, args=(W1, genome),  bounds=bnds, constraints =cons1, tol=1e-30)
@@ -335,44 +328,35 @@ def add_signatures(W, genome, cutoff=0.05, presentSignatures=[], toBeAdded="all"
                 newExposure = list(solution) #for nnls
             #print(W1)
             #convert the newExposure vector into list type structure
-            
-            
-            
-            # get the maximum value of the new Exposure
-            maxcoef = max(newExposure)
-            idxmaxcoef = newExposure.index(maxcoef)
-            
-            newExposure = np.round(newExposure)
-            
+
+            newExposure = roundConserveSum(newExposure)
             # We may need to tweak the maximum value of the new exposure to keep the total number of mutation equal to the original mutations in a genome
-            if np.sum(newExposure)!=maxmutation:
-                newExposure[idxmaxcoef] = round(newExposure[idxmaxcoef])+maxmutation-sum(newExposure)
-             
-            
-            
+            if np.sum(newExposure)!=maxmutation: raise ValueError("Mutation count not conserved")
+
+
             if metric=='cosine':
                 newSimilarity = 1-cos_sim(genome[:,0], est_genome)
             elif metric=='l2':
                 newSimilarity = np.linalg.norm(genome[:,0]-est_genome , ord=2)/np.linalg.norm(genome[:,0], ord=2)
-            
+
             if sig in check_rule_negatives:
-                
+
                 newSimilarity = newSimilarity*check_rule_penalty
-                
-            difference = originalSimilarity -  newSimilarity 
-            
+
+            difference = originalSimilarity -  newSimilarity
+
             # record the best values so far that creates the best difference
             if difference>bestDifference:
                 bestDifference = difference
                 bestSimilarity = newSimilarity
                 loopRecord = [newExposure, W1, sig]  #recording the cosine difference, the new exposure and the index of the best signauture
-                
-        
-         
-         
-        if originalSimilarity - bestSimilarity>cutoff: 
-            
-            
+
+
+
+
+        if originalSimilarity - bestSimilarity>cutoff:
+
+
             originalSimilarity = bestSimilarity
             init_listed_idx.append(loopRecord[2])  #add the qualified signature in the signature list
             init_nonlisted_idx.remove(loopRecord[2]) #remover the qualified signature from the to be added list
@@ -387,18 +371,18 @@ def add_signatures(W, genome, cutoff=0.05, presentSignatures=[], toBeAdded="all"
                     print("L2 norm: ", originalSimilarity)
                 print("\n")
             if len(init_nonlisted_idx)!= 0:
-                
+
                 continue
             else:
                 break
         else:
-            
+
             break
-     
+
     #print("Good so far")
     #print(finalRecord)
-    
-    dictExposure= {"similarity":finalRecord[0], "exposures":finalRecord[1], "signatures": finalRecord[2]}  
+
+    dictExposure= {"similarity":finalRecord[0], "exposures":finalRecord[1], "signatures": finalRecord[2]}
     addExposure = np.zeros([W.shape[1]])
     addExposure[dictExposure["signatures"]]=dictExposure["exposures"]
     #print(cos_sim(genome[:,0], np.dot(W,addExposure)))
@@ -416,34 +400,34 @@ def add_signatures(W, genome, cutoff=0.05, presentSignatures=[], toBeAdded="all"
 def remove_all_single_signatures(W, H, genomes, metric="l2", solver = "nnls", cutoff=0.05, background_sigs = [], verbose=False):
     # make the empty list of the successfull combinations
     signature_ids=sub.make_letter_ids(idlenth = W.shape[1], mtype = "Signature ")
-    
+
     current_signatures=signature_ids
     #print(current_signatures)
-    successList = [0,[],0] 
+    successList = [0,[],0]
     background_sig = copy.deepcopy(background_sigs)
-    
+
     #setting the base_similarity
     base_H_index = list(np.nonzero(H)[0])
     reg = nnls(W[:,base_H_index],genomes)
     base_weights = reg[0]
-    
+
     if metric == "cosine":
         # get the cos_similarity with sample for the oringinal W and H[:,i]
         originalSimilarity= 1-cos_sim(genomes, np.dot(W[:,base_H_index], base_weights))
         if verbose==True:
             print("originalSimilarity", 1-originalSimilarity)
     elif metric == "l2":
-       
+
         originalSimilarity = np.linalg.norm(genomes-np.dot(W[:,base_H_index], base_weights) , ord=2)/np.linalg.norm(genomes, ord=2)
         if verbose==True:
             print("originalSimilarity", originalSimilarity)
     # make the original exposures of specific sample round
-    oldExposures = np.round(H)
-    
+    oldExposures = roundConserveSum(H)
+
     # set the flag for the while loop
     if len(oldExposures[np.nonzero(oldExposures)])>1:
         Flag = True
-    else: 
+    else:
         Flag = False
         if metric=="cosine":
             return oldExposures, 1-originalSimilarity, cos_sim(genomes, np.dot(W,H))  #first value is the exprosure, second value is the similarity (based on the similarity matic), third value is the cosine similarity
@@ -451,119 +435,110 @@ def remove_all_single_signatures(W, H, genomes, metric="l2", solver = "nnls", cu
             return oldExposures, originalSimilarity, cos_sim(genomes, np.dot(W,H))    #first value is the exprosure, second value is the similarity (based on the similarity matic), third value is the cosine similarity
     # The while loop starts here
     current_signatures=sub.get_items_from_index(signature_ids,np.nonzero(oldExposures)[0])
-    while Flag: 
-        
+    while Flag:
+
         # get the list of the indices those already have zero values
         if len(successList[1]) == 0:
-            initialZerosIdx = list(np.where(oldExposures==0)[0]) 
+            initialZerosIdx = list(np.where(oldExposures==0)[0])
             #get the indices to be selected
-            selectableIdx = list(np.where(oldExposures>0)[0]) 
-        elif len(successList[1]) > 1: 
-            initialZerosIdx = list(np.where(successList[1]==0)[0]) 
+            selectableIdx = list(np.where(oldExposures>0)[0])
+        elif len(successList[1]) > 1:
+            initialZerosIdx = list(np.where(successList[1]==0)[0])
             #get the indices to be selected
             selectableIdx = list(np.where(successList[1]>0)[0])
         else:
             print("iteration is completed")
             #break
-        
-        
+
+
         # get the total mutations for the given sample
         maxmutation = round(np.sum(genomes))
-        
+
         # new signature matrix omiting the column for zero
         #Winit = np.delete(W, initialZerosIdx, 1)
         Winit = W[:,selectableIdx]
-        
+
         # set the initial cos_similarity or other similarity distance
         record  = [np.inf, [], 1]   #
         # get the number of current nonzeros
         l= Winit.shape[1]
-        
+
         background_sig = get_changed_background_sig_idx(list(oldExposures), background_sig)
-        
+
         for i in range(l):
-            
+
             if i in background_sig:
                 continue
-            
+
             loopSelection = list(range(l))
             del loopSelection[i]
-            
+
             W1 = Winit[:,loopSelection]
-           
-            
+
+
             #initialize the guess
             x0 = np.random.rand(l-1, 1)*maxmutation
             x0= x0/np.sum(x0)*maxmutation
-            
+
             #set the bounds and constraints
-            bnds = create_bounds([], genomes, W1.shape[1]) 
-            cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genomes]} 
-            
+            bnds = create_bounds([], genomes, W1.shape[1])
+            cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genomes]}
+
             #the optimization step
             if solver == "slsqp":
                 sol = minimize(parameterized_objective2_custom, x0, args=(W1, genomes),  bounds=bnds, constraints =cons1, tol=1e-15)
-                
+
                 #print (sol.success)
                 #print (sol.x)
-                
+
                 #convert the newExposure vector into list type structure
                 newExposure = list(sol.x)
             if solver == "nnls":
-                ### using NNLS algorithm 
+                ### using NNLS algorithm
                 reg = nnls(W1,genomes)
                 weights = reg[0]
                 newSample = np.dot(W1, weights)
                 normalised_weights = weights/sum(weights)
-                solution = normalised_weights*sum(genomes)                
+                solution = normalised_weights*sum(genomes)
                 newExposure = list(solution)
-                
-            #insert the loopZeros in its actual position 
+
+            #insert the loopZeros in its actual position
             newExposure.insert(i, 0)
-            
+
             #insert zeros in the required position the newExposure matrix
             initialZerosIdx.sort()
-            
+
             for zeros in initialZerosIdx:
                 newExposure.insert(zeros, 0)
-            
-            # get the maximum value the new Exposure
-            #maxcoef = max(newExposure)
-            #idxmaxcoef = newExposure.index(maxcoef)
-            
-            #newExposure = np.round(newExposure)
-            
-            
-            #if np.sum(newExposure)!=maxmutation:
-                #newExposure[idxmaxcoef] = round(newExposure[idxmaxcoef])+maxmutation-sum(newExposure)
-                
+
+
             newExposure=np.array(newExposure)
-            
+
             if verbose==True:
                 #print(newExposure)
                 print("\nRemoving {}".format(current_signatures[i]))
             if metric == "cosine":
-                newSimilarity = 1-cos_sim(genomes, newSample) 
+                newSimilarity = 1-cos_sim(genomes, newSample)
                 if verbose==True:
-                    print("newSimilarity",1-newSimilarity) 
+                    print("newSimilarity",1-newSimilarity)
             elif metric == "l2":
                 newSimilarity = np.linalg.norm(genomes-newSample, ord=2)/np.linalg.norm(genomes, ord=2)
                 if verbose==True:
-                    print("newSimilarity",newSimilarity) 
-            difference =  newSimilarity-originalSimilarity 
+                    print("newSimilarity",newSimilarity)
+            difference =  newSimilarity-originalSimilarity
             if difference<0:
                 difference=cutoff+1e-100
             if verbose==True:
-                print("difference", difference) 
+                print("difference", difference)
             if difference<record[0]:
                 record = [difference, newExposure, newSimilarity]
-                
+
                 #print("difference", difference)
             if verbose==True:
                 print("--------------------------------------")
-            
-        if verbose==True:    
-            print("\n############################\n############################") 
+
+        if verbose==True:
+            print("\n############################\n############################")
             #print("Selected Exposure")
             #print(record[1])
             selected_sigs=sub.get_items_from_index(signature_ids,np.nonzero(record[1])[0])
@@ -575,29 +550,29 @@ def remove_all_single_signatures(W, H, genomes, metric="l2", solver = "nnls", cu
             print("Current Signatures: {}".format(selected_sigs))
             print("****************************\n****************************\n\n")
             #print ("This loop's selection is {}".format(record))
-        
-        if record[0]>cutoff:   
+
+        if record[0]>cutoff:
             Flag=False
         elif len(record[1][np.nonzero(record[1])])==1:
-            successList = record 
+            successList = record
             Flag=False
         else:
             successList = record
             background_sig = get_changed_background_sig_idx(list(record[1]), background_sig)
             originalSimilarity=record[2]
-        
+
         #print("The loop selection is {}".format(successList))
-        
+
         #print (Flag)
         #print ("\n\n")
-    
+
     #print ("The final selection is {}".format(successList))
-    
+
     if len(successList[1])==0:
         successList = [0.0, oldExposures, originalSimilarity]
-    
+
     if verbose==True:
-        print("\n") 
+        print("\n")
         print("Final Exposure")
         print(successList[1])
         if metric=="cosine":
@@ -606,7 +581,7 @@ def remove_all_single_signatures(W, H, genomes, metric="l2", solver = "nnls", cu
             print("Final Similarity: ", successList[2])
     H = successList[1]
     return H, successList[2], cos_sim(genomes, np.dot(W,H)) #first value is the exprosure, second value is the similarity (based on the similarity matic), third value is the cosine similarity
-    
+
 
 
 def remove_all_single_signatures_pool(indices, W, exposures, totoalgenomes):
@@ -614,125 +589,119 @@ def remove_all_single_signatures_pool(indices, W, exposures, totoalgenomes):
     H = exposures[:,i]
     genomes= totoalgenomes[:,i]
     # make the empty list of the successfull combinations
-    successList = [0,[],0] 
+    successList = [0,[],0]
     # get the cos_similarity with sample for the oringinal W and H[:,i]
     originalSimilarity= cos_sim(genomes, np.dot(W, H))
     # make the original exposures of specific sample round
-    oldExposures = np.round(H)
-    
+    oldExposures = roundConserveSum(H)
+
     # set the flag for the while loop
     if len(oldExposures[np.nonzero(oldExposures)])>1:
         Flag = True
-    else: 
+    else:
         Flag = False
         return oldExposures
     # The while loop starts here
-    while Flag: 
-        
+    while Flag:
+
         # get the list of the indices those already have zero values
         if len(successList[1]) == 0:
-            initialZerosIdx = list(np.where(oldExposures==0)[0]) 
+            initialZerosIdx = list(np.where(oldExposures==0)[0])
             #get the indices to be selected
-            selectableIdx = list(np.where(oldExposures>0)[0]) 
-        elif len(successList[1]) > 1: 
-            initialZerosIdx = list(np.where(successList[1]==0)[0]) 
+            selectableIdx = list(np.where(oldExposures>0)[0])
+        elif len(successList[1]) > 1:
+            initialZerosIdx = list(np.where(successList[1]==0)[0])
             #get the indices to be selected
             selectableIdx = list(np.where(successList[1]>0)[0])
         else:
             print("iteration is completed")
             #break
-        
-        
+
+
         # get the total mutations for the given sample
         maxmutation = round(np.sum(genomes))
-        
+
         # new signature matrix omiting the column for zero
         #Winit = np.delete(W, initialZerosIdx, 1)
         Winit = W[:,selectableIdx]
-        
+
         # set the initial cos_similarity
-        record  = [0.11, []] 
+        record  = [0.11, []]
         # get the number of current nonzeros
         l= Winit.shape[1]
-        
+
         for i in range(l):
             #print(i)
             loopSelection = list(range(l))
             del loopSelection[i]
             #print (loopSelection)
             W1 = Winit[:,loopSelection]
-           
-            
+
+
             #initialize the guess
             x0 = np.random.rand(l-1, 1)*maxmutation
             x0= x0/np.sum(x0)*maxmutation
-            
+
             #set the bounds and constraints
-            bnds = create_bounds([], genomes, W1.shape[1]) 
-            cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genomes]} 
-            
+            bnds = create_bounds([], genomes, W1.shape[1])
+            cons1 ={'type': 'eq', 'fun': constraints1, 'args':[genomes]}
+
             #the optimization step
             sol = minimize(parameterized_objective2_custom, x0, args=(W1, genomes),  bounds=bnds, constraints =cons1, tol=1e-15)
-            
+
             #print (sol.success)
             #print (sol.x)
-            
+
             #convert the newExposure vector into list type structure
             newExposure = list(sol.x)
-            
-            #insert the loopZeros in its actual position 
+
+            #insert the loopZeros in its actual position
             newExposure.insert(i, 0)
-            
+
             #insert zeros in the required position the newExposure matrix
             initialZerosIdx.sort()
             for zeros in initialZerosIdx:
                 newExposure.insert(zeros, 0)
-            
-            # get the maximum value the new Exposure
-            maxcoef = max(newExposure)
-            idxmaxcoef = newExposure.index(maxcoef)
-            
-            newExposure = np.round(newExposure)
-            
-            
-            if np.sum(newExposure)!=maxmutation:
-                newExposure[idxmaxcoef] = round(newExposure[idxmaxcoef])+maxmutation-sum(newExposure)
-                
-            
+
+            newExposure = roundConserveSum(newExposure)
+            # We may need to tweak the maximum value of the new exposure to keep the total number of mutation equal to the original mutations in a genome
+            if np.sum(newExposure)!=maxmutation: raise ValueError("Mutation count not conserved")
+
+
             newSample = np.dot(W, newExposure)
-            newSimilarity = cos_sim(genomes, newSample) 
-             
+            newSimilarity = cos_sim(genomes, newSample)
+
             difference = originalSimilarity - newSimilarity
             #print(originalSimilarity)
             #print(newSample)
             #print(newExposure)
             #print(newSimilarity)
-            
+
             #print(difference)
             #print (newExposure)
             #print (np.round(H))
             #print ("\n\n")
-             
+
             if difference<record[0]:
                 record = [difference, newExposure, newSimilarity]
-            
-            
+
+
         #print ("This loop's selection is {}".format(record))
-        
-        if record[0]>0.01:   
+
+        if record[0]>0.01:
             Flag=False
         elif len(record[1][np.nonzero(record[1])])==1:
-            successList = record 
+            successList = record
             Flag=False
         else:
             successList = record
         #print("The loop selection is {}".format(successList))
-        
+
         #print (Flag)
         #print ("\n\n")
-    
+
     #print ("The final selection is {}".format(successList))
-    
+
     if len(successList[1])==0:
         successList = [0.0, oldExposures, originalSimilarity]
     #print ("one sample completed")
@@ -742,42 +711,42 @@ def remove_all_single_signatures_pool(indices, W, exposures, totoalgenomes):
 
 
 def add_remove_signatures(W,
-                          sample, 
-                          metric="l2", 
-                          solver="nnls", 
-                          background_sigs = [], 
-                          permanent_sigs = [], 
-                          candidate_sigs="all", 
-                          add_penalty = 0.05, 
+                          sample,
+                          metric="l2",
+                          solver="nnls",
+                          background_sigs = [],
+                          permanent_sigs = [],
+                          candidate_sigs="all",
+                          add_penalty = 0.05,
                           remove_penalty=0.01,
                           check_rule_negatives =[],
-                          checkrule_penalty = 1.00, 
-                          allsigids = False, 
-                          directory = os.getcwd()+"/Signature_assaignment_logfile.txt", 
+                          checkrule_penalty = 1.00,
+                          allsigids = False,
+                          directory = os.getcwd()+"/Signature_assaignment_logfile.txt",
                           connected_sigs=True,
                           verbose=False):
-    
+
     lognote = open(directory, 'a')
- 
+
     maxmutation=np.sum(np.array(sample))
-    
+
     always_background = copy.deepcopy(permanent_sigs)
-    M = sample   
+    M = sample
     if candidate_sigs == "all":
         candidate_sigs = list(range(W.shape[1]))
     #first add each signatures
     original_distance = np.inf # a big number
     layer = 0
-    
+
     # check the cosine_similarity with 4 signatures (highest)
     cosine_similarity_with_four_signatures = 1.0 # a value that will allow the signature not be reported as novel signature
-    
-    #set the signature's name 
+
+    #set the signature's name
     if type(allsigids) != bool:
         allsigids = sub.get_items_from_index(allsigids,candidate_sigs)
     else:
         allsigids = candidate_sigs
-        
+
     while True:
         if verbose:
             print("\n\n\n\n!!!!!!!!!!!!!!!!!!STARTING LAYER: ", layer)
@@ -785,55 +754,55 @@ def add_remove_signatures(W,
         layer=layer+1
         layer_original_distance = np.inf  #a big number
         sigsToBeAdded = list(set(candidate_sigs)-set(background_sigs))
-        #set the signature's name 
+        #set the signature's name
         if type(allsigids) != bool:
             allsigidsToBeAdded = sub.get_items_from_index(allsigids,sigsToBeAdded)
         else:
             allsigidsToBeAdded = sigsToBeAdded
-        
+
         for i,j in zip(sigsToBeAdded, allsigidsToBeAdded):
-            loop_sig = [i] 
-            
+            loop_sig = [i]
+
             background_sigs = list(set(background_sigs).union(set(always_background)))
             if connected_sigs==True:
                 background_sigs = add_connected_sigs(background_sigs, list(allsigids))
-            
-            add_exposures, add_distance, _ = add_signatures(W, M[:,np.newaxis], presentSignatures=copy.deepcopy(background_sigs), toBeAdded=loop_sig, 
-                                                  metric="l2", verbose=False, check_rule_negatives=check_rule_negatives, check_rule_penalty=checkrule_penalty, cutoff=add_penalty) 
-            
+
+            add_exposures, add_distance, _ = add_signatures(W, M[:,np.newaxis], presentSignatures=copy.deepcopy(background_sigs), toBeAdded=loop_sig,
+                                                  metric="l2", verbose=False, check_rule_negatives=check_rule_negatives, check_rule_penalty=checkrule_penalty, cutoff=add_penalty)
+
             if verbose:
-                print("\n\n\n################## Add Index {} ########################".format(j)) 
+                print("\n\n\n################## Add Index {} ########################".format(j))
                 print(np.nonzero(add_exposures)[0])
                 print(sigsToBeAdded)
                 print(add_distance)
-                
-                
+
+
             remove_exposures, remove_distance, _ = remove_all_single_signatures(W, add_exposures, M, background_sigs = always_background, metric="l2", verbose = False, cutoff=remove_penalty)
-            
+
             if verbose:
                 print("\n################## Remove ########################")
                 print(np.nonzero(remove_exposures)[0])
                 print(remove_distance)
-            # check if there is any change between the add and remove signatures and assign the distance and exposure accoridingly    
+            # check if there is any change between the add and remove signatures and assign the distance and exposure accoridingly
             if (np.nonzero(add_exposures)[0].all()==np.nonzero(remove_exposures)[0].all()) and np.nonzero(add_exposures)[0].shape == np.nonzero(remove_exposures)[0].shape:
                 distance = add_distance
                 exposures = add_exposures
             else:
                 distance = remove_distance
                 exposures = remove_exposures
-            
+
             if distance < layer_original_distance:
                 selected_signatures = np.nonzero(exposures)[0]
-                layer_original_distance = distance 
+                layer_original_distance = distance
                 activities = exposures
         if verbose:
             print("\n\n#################### After Add-Remove #################################")
             print(selected_signatures)
             print(layer_original_distance)
-        
-        lognote.write("Best Signature Composition {}\n".format(sub.get_items_from_index(allsigids,selected_signatures)))    
-        lognote.write("L2 Error % {}\n".format(round(layer_original_distance, 2))) 
-        lognote.write("Cosine Similarity {}\n".format(round(cos_sim(M, np.dot(W,activities)),2)))         
+
+        lognote.write("Best Signature Composition {}\n".format(sub.get_items_from_index(allsigids,selected_signatures)))
+        lognote.write("L2 Error % {}\n".format(round(layer_original_distance, 2)))
+        lognote.write("Cosine Similarity {}\n".format(round(cos_sim(M, np.dot(W,activities)),2)))
         if layer_original_distance < original_distance:
             original_distance = layer_original_distance
             background_sigs = list(selected_signatures)
@@ -848,27 +817,21 @@ def add_remove_signatures(W,
             correlation,_=scipy.stats.pearsonr(M, N)
             correlation=round(correlation,2)
             break
-    
-    
-    # get the maximum value of the new Exposure
-    maxcoef = np.max(finalactivities)
-    idxmaxcoef = list(finalactivities).index(maxcoef)
-    
-    finalactivities = np.round(finalactivities)
-    
+
+    # Round activities conserving total mutation count
+    finalactivities = roundConserveSum(finalactivities)
     # We may need to tweak the maximum value of the new exposure to keep the total number of mutation equal to the original mutations in a genome
-    if np.sum(finalactivities)!=maxmutation:
-        finalactivities[idxmaxcoef] = round(finalactivities[idxmaxcoef])+maxmutation-np.sum(finalactivities) 
-        
+    if np.sum(finalactivities)!=round(maxmutation): raise ValueError("Mutation count not conserved")
+
     if verbose:
-        print("\n########################## Final ###########################")        
+        print("\n########################## Final ###########################")
         print(background_sigs)
         print(original_distance)
         print(finalactivities)
     lognote.write("\n#################### Final Composition #################################\n")
-    lognote.write("{}\n".format(sub.get_items_from_index(allsigids,selected_signatures)))    
-    lognote.write("L2 Error % {}\n".format(round(original_distance, 2))) 
-    lognote.write("Cosine Similarity {}\n".format(round(cos_sim(M, np.dot(W,finalactivities)),2)))        
+    lognote.write("{}\n".format(sub.get_items_from_index(allsigids,selected_signatures)))
+    lognote.write("L2 Error % {}\n".format(round(original_distance, 2)))
+    lognote.write("Cosine Similarity {}\n".format(round(cos_sim(M, np.dot(W,finalactivities)),2)))
     #close lognote
     lognote.close()
     #newExposure, newSimilarity = fit_signatures(W[:,list(background_sigs)], M, metric="l2")


### PR DESCRIPTION
Rounds mutation array conserving the total - more stable than reducing the max value as a correction.

The previous solution in the code was to apply np.round then correct the max. count for the difference with the original total. In some cases this could significantly shift the max value and as in [issue#28](https://github.com/AlexandrovLab/SigProfilerAssignment/issues/28#issue-1334436883) even send it negative.

New solution - round down the first N entries ordered by residuals (value - floor) where N is the difference between the original total and the sum of the ceiled values. The others are rounded up.
e.g.
2.2,2.4,2.4 -> 2,2,3
2.5,2.7,2.8 -> 2,3,3
(under the previous solution the last one would have become 3,3,2 such that the max value becomes the min value). All entries will be set to the integer above or below their input value, the ordering of entry values is unchanged and it shouldn't be possible for any values to go negative.

I've added some error captures which will exit if the total of the new array is not the same as the input total but in my tests they've never been triggered so I think it's working.