### PR TITLE
v0.1.5: Add text for stability and mutation count to the de novo signature plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Additional functionalities for downstream analysis of _de novo_ extraction of mu
 
 ## <a name="citation"></a> Citation
 
-Díaz-Gay, M., Vangara, R., Barnes, M., ... & Alexandrov, L. B. (2023). Assigning mutational signatures to individual samples and individual somatic mutations with SigProfilerAssignment, bioRxiv, 2023-07. doi: https://doi.org/10.1101/2023.07.10.548264
+Díaz-Gay, M., Vangara, R., Barnes, M., ... & Alexandrov, L. B. (2023). Assigning mutational signatures to individual samples and individual somatic mutations with SigProfilerAssignment, Bioinformatics, 2023-07. doi: [https://doi.org/10.1093/bioinformatics/btad756](https://doi.org/10.1093/bioinformatics/btad756)
 
 ## <a name="copyright"></a> Copyright
 This software and its documentation are copyright 2022 as a part of the SigProfiler project. The SigProfilerAssignment framework is free software and is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.

--- a/SigProfilerAssignment/decompose_subroutines.py
+++ b/SigProfilerAssignment/decompose_subroutines.py
@@ -1448,6 +1448,8 @@ def make_final_solution(
                 solution_prefix,
                 m,
                 True,
+                custom_text_upper=signature_stabilities,
+                custom_text_middle=signature_total_mutations,
             )
         else:
             custom_signatures_plot(processes, layer_directory + "/Signatures")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 if os.path.exists("dist"):
     shutil.rmtree("dist")
 
-VERSION = "0.1.4"
+VERSION = "0.1.5"
 
 
 def write_version_py(filename="SigProfilerAssignment/version.py"):
@@ -15,7 +15,7 @@ def write_version_py(filename="SigProfilerAssignment/version.py"):
 # THIS FILE IS GENERATED FROM SigProfilerAssignment SETUP.PY
 short_version = '%(version)s'
 version = '%(version)s'
-Update = 'v0.1.4: Add SV decomposition plotting.'
+Update = 'v0.1.5: Add text for stability and mutation count to the de novo signature plots.'
 
     
     """
@@ -37,7 +37,7 @@ requirements = [
     "numpy>=1.21.2",
     "pandas>=1.2.4,<2.0.0",
     "SigProfilerMatrixGenerator>=1.2.17",
-    "sigProfilerPlotting>=1.3.20",
+    "sigProfilerPlotting>=1.3.23",
     "statsmodels>=0.9.0",
     "scikit-learn>=0.24.2",
     "psutil>=5.6.1",


### PR DESCRIPTION
* Use SigProfilerPlottings custom_text_upper and custom_text_middle to include the stability and mutation count to the de novo signature plots for SBS4608.