### PR TITLE
v0.2.6: Add rn7/mm39 genome support and bump pypdf for security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.2.6] - 2025-09-17
+
+### Added
+- Support for assigning mutational signatures using the `rn7` and `mm39` genome builds.
+
+### Security
+- Updated dependency requirement to `pypdf>=6.0.0` (previous versions contained a security vulnerability).
+
 ## [0.2.5] - 2025-08-07
 
 ### Added

--- a/SigProfilerAssignment/decompose_subroutines.py
+++ b/SigProfilerAssignment/decompose_subroutines.py
@@ -40,19 +40,13 @@ def getProcessAvg(
 ):
     paths = spa.__path__[0]
 
-    if (
-        genome_build == "GRCh37"
-        or genome_build == "GRCh38"
-        or genome_build == "mm9"
-        or genome_build == "mm10"
-        or genome_build == "rn6"
-    ):
+    if genome_build in ["GRCh37", "GRCh38", "mm9", "mm10", "mm39", "rn6", "rn7"]:
         genome_build = genome_build
     else:
         print(
             "The selected genome build is "
             + str(genome_build)
-            + ". COSMIC signatures are available only for GRCh37/38, mm9/10 and rn6 genomes. So, the genome build is reset to GRCh37."
+            + ". COSMIC signatures are available only for GRCh37/38, mm9/10/39 and rn6/7 genomes. So, the genome build is reset to GRCh37."
         )
         genome_build = "GRCh37"
     if samples.shape[0] == 96:

--- a/SigProfilerAssignment/decomposition.py
+++ b/SigProfilerAssignment/decomposition.py
@@ -271,7 +271,7 @@ def spa_analyze(
         activities: A string. Path to a tab delimilted file that contains the activity table where the rows are sample IDs and colunms are signature IDs.
         samples: A string. Path to a tab delimilted file that contains the activity table where the rows are mutation types and colunms are sample IDs.
         output: A string. Path to the output folder.
-        genome_build = A string. The reference genome build. List of supported genomes: "GRCh37", "GRCh38", "mm9", "mm10" and "rn6". The default value is "GRCh37". If the selected genome is not in the supported list, the default genome will be used.
+        genome_build = A string. The reference genome build. List of supported genomes: "GRCh37", "GRCh38", "mm9", "mm10", "mm39", "rn6", and "rn7". The default value is "GRCh37". If the selected genome is not in the supported list, the default genome will be used.
         verbose = Boolean. Prints statements. Default value is False.
         exome = Boolean. Defines if the exome renormalized signatures will be used. The default value is False.
         sample_reconstruction_plots (str): Select output format for sample reconstruction plots. Valid options are {'pdf', 'png', 'both', 'none'}. Default is 'none'.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,27 +6,27 @@
 #
 about-time==4.2.1
     # via alive-progress
-alive-progress==3.1.5
+alive-progress==3.3.0
     # via SigProfilerAssignment (setup.py)
-chardet==5.2.0
+charset-normalizer==3.4.3
     # via reportlab
-contourpy==1.2.1
+contourpy==1.3.3
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-fonttools==4.53.1
+fonttools==4.60.0
     # via matplotlib
-grapheme==0.6.0
+graphemeu==0.7.2
     # via alive-progress
-joblib==1.4.2
+joblib==1.5.2
     # via scikit-learn
-kiwisolver==1.4.5
+kiwisolver==1.4.9
     # via matplotlib
-matplotlib==3.9.2
+matplotlib==3.10.6
     # via
     #   sigprofilermatrixgenerator
     #   sigprofilerplotting
-numpy==1.26.4
+numpy==2.3.3
     # via
     #   SigProfilerAssignment (setup.py)
     #   contourpy
@@ -37,58 +37,57 @@ numpy==1.26.4
     #   scipy
     #   sigprofilermatrixgenerator
     #   statsmodels
-packaging==24.1
+packaging==25.0
     # via
     #   matplotlib
     #   statsmodels
-pandas==1.5.3
+pandas==2.3.2
     # via
     #   SigProfilerAssignment (setup.py)
     #   sigprofilermatrixgenerator
     #   sigprofilerplotting
     #   statsmodels
-patsy==0.5.6
+patsy==1.0.1
     # via statsmodels
-pillow==10.4.0
+pdf2image==1.17.0
+    # via SigProfilerAssignment (setup.py)
+pillow==11.3.0
     # via
     #   matplotlib
+    #   pdf2image
     #   reportlab
     #   sigprofilerplotting
-pymupdf==1.24.9
-    # via SigProfilerAssignment (setup.py)
-pymupdfb==1.24.9
-    # via pymupdf
-pyparsing==3.1.2
+pyparsing==3.2.4
     # via matplotlib
-pypdf==4.3.1
+pypdf==6.0.0
     # via SigProfilerAssignment (setup.py)
 python-dateutil==2.9.0.post0
     # via
     #   matplotlib
     #   pandas
-pytz==2024.1
+pytz==2025.2
     # via pandas
-reportlab==4.2.2
+reportlab==4.4.3
     # via SigProfilerAssignment (setup.py)
-scikit-learn==1.5.1
+scikit-learn==1.7.2
     # via sigprofilerplotting
-scipy==1.14.0
+scipy==1.16.2
     # via
     #   SigProfilerAssignment (setup.py)
     #   scikit-learn
     #   sigprofilermatrixgenerator
     #   statsmodels
-sigprofilermatrixgenerator==1.2.28
+sigprofilermatrixgenerator==1.3.5
     # via SigProfilerAssignment (setup.py)
-sigprofilerplotting==1.3.24
+sigprofilerplotting==1.4.1
     # via
     #   SigProfilerAssignment (setup.py)
     #   sigprofilermatrixgenerator
-six==1.16.0
-    # via
-    #   patsy
-    #   python-dateutil
-statsmodels==0.14.2
+six==1.17.0
+    # via python-dateutil
+statsmodels==0.14.5
     # via sigprofilermatrixgenerator
-threadpoolctl==3.5.0
+threadpoolctl==3.6.0
     # via scikit-learn
+tzdata==2025.2
+    # via pandas

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 if os.path.exists("dist"):
     shutil.rmtree("dist")
 
-VERSION = "0.2.5"
+VERSION = "0.2.6"
 
 
 def write_version_py(filename="SigProfilerAssignment/version.py"):
@@ -15,7 +15,7 @@ def write_version_py(filename="SigProfilerAssignment/version.py"):
 # THIS FILE IS GENERATED FROM SigProfilerAssignment SETUP.PY
 short_version = '%(version)s'
 version = '%(version)s'
-Update = 'v0.2.5:  Support for generating decomposition plots for custom signature sets.'
+Update = 'v0.2.6:  Support for assigning signatures for rn7 and mm39 genomes.'
 
     """
     fh = open(filename, "w")
@@ -38,7 +38,7 @@ requirements = [
     "SigProfilerMatrixGenerator>=1.3.0",
     "sigProfilerPlotting>=1.4.0",
     "reportlab>=3.5.42",
-    "pypdf>=5.0.0",
+    "pypdf>=6.0.0",
     "alive_progress>=2.4.1",
     "pdf2image>=1.16.0",  # replacing PyMuPDF
     # Note: 'poppler' is required as a system dependency for pdf2image


### PR DESCRIPTION
- Added support for assigning mutational signatures with rn7 and mm39 genome builds.
- Updated dependency requirement to pypdf>=6.0.0 to address security issues in earlier versions.