### PR TITLE
Add parameter to disable automatic background signature addition

### DIFF
--- a/SigProfilerAssignment/Analyzer.py
+++ b/SigProfilerAssignment/Analyzer.py
@@ -25,6 +25,7 @@ def decompose_fit(
     export_probabilities_per_mutation=False,
     volume=None,
     cpu=-1,
+    add_background_signatures=True,
 ):
     decomp.spa_analyze(
         samples=samples,
@@ -53,6 +54,7 @@ def decompose_fit(
         export_probabilities_per_mutation=export_probabilities_per_mutation,
         volume=volume,
         cpu=cpu,
+        add_background_signatures=add_background_signatures,
     )
 
 
@@ -79,6 +81,7 @@ def denovo_fit(
     export_probabilities_per_mutation=False,
     volume=None,
     cpu=-1,
+    add_background_signatures=True,
 ):
     decomp.spa_analyze(
         samples=samples,
@@ -106,6 +109,7 @@ def denovo_fit(
         export_probabilities_per_mutation=export_probabilities_per_mutation,
         volume=volume,
         cpu=cpu,
+        add_background_signatures=add_background_signatures,
     )
 
 
@@ -133,6 +137,7 @@ def cosmic_fit(
     sample_reconstruction_plots=False,
     volume=None,
     cpu=-1,
+    add_background_signatures=True,
 ):
     decomp.spa_analyze(
         samples=samples,
@@ -161,4 +166,5 @@ def cosmic_fit(
         sample_reconstruction_plots=sample_reconstruction_plots,
         volume=volume,
         cpu=cpu,
+        add_background_signatures=add_background_signatures,
     )

--- a/SigProfilerAssignment/controllers/cli_controller.py
+++ b/SigProfilerAssignment/controllers/cli_controller.py
@@ -154,6 +154,14 @@ def parse_arguments_common(args: List[str], description: str) -> argparse.Namesp
             "'png' (PNG only, PDF removed)."
         ),
     )
+    parser.add_argument(
+        "--add_background_signatures",
+        type=str2bool,
+        nargs="?",
+        const=True,
+        default=True,
+        help="Automatically add background signatures SBS1 and SBS5 (default: True).",
+    )
     
 
     return parser.parse_args(args)
@@ -189,6 +197,7 @@ class CliController:
             context_type=parsed_args.context_type,
             export_probabilities=parsed_args.export_probabilities,
             export_probabilities_per_mutation=parsed_args.export_probabilities_per_mutation,
+            add_background_signatures=parsed_args.add_background_signatures,
         )
 
     def dispatch_denovo_fit(self, user_args: List[str]) -> None:
@@ -219,6 +228,7 @@ class CliController:
             context_type=parsed_args.context_type,
             export_probabilities=parsed_args.export_probabilities,
             export_probabilities_per_mutation=parsed_args.export_probabilities_per_mutation,
+            add_background_signatures=parsed_args.add_background_signatures,
         )
 
     def dispatch_cosmic_fit(self, user_args: List[str]) -> None:
@@ -250,4 +260,5 @@ class CliController:
             export_probabilities=parsed_args.export_probabilities,
             export_probabilities_per_mutation=parsed_args.export_probabilities_per_mutation,
             sample_reconstruction_plots=parsed_args.sample_reconstruction_plots,
+            add_background_signatures=parsed_args.add_background_signatures,
         )

--- a/SigProfilerAssignment/decompose_subroutines.py
+++ b/SigProfilerAssignment/decompose_subroutines.py
@@ -300,6 +300,7 @@ def signature_decomposition(
     exome=False,
     m_for_subgroups="SBS",
     volume=None,
+    add_background_signatures=True,
 ):
     originalProcessAvg = originalProcessAvg.reset_index()
     if not os.path.exists(directory + "/Solution_Stats"):
@@ -395,7 +396,10 @@ def signature_decomposition(
 
     # only for SBS96
     if mtype == "96" or mtype == "288" or mtype == "1536":
-        bgsigs = get_indeces(list(signames), ["SBS1", "SBS5"])
+        if add_background_signatures:
+            bgsigs = get_indeces(list(signames), ["SBS1", "SBS5"])
+        else:
+            bgsigs = []
     else:
         bgsigs = []
 
@@ -691,7 +695,10 @@ def signature_decomposition(
 
     # only for SBS96
     if mtype == "96" or mtype == "288" or mtype == "1536":
-        background_sigs = get_indeces(list(detected_signatures), ["SBS1", "SBS5"])
+        if add_background_signatures:
+            background_sigs = get_indeces(list(detected_signatures), ["SBS1", "SBS5"])
+        else:
+            background_sigs = []
         # add connected signatures
         different_signatures = ss.add_connected_sigs(
             different_signatures, list(signames)
@@ -874,8 +881,10 @@ def process_sample(args):
             set().union(list(np.nonzero(exposureAvg[:, r])[0]), background_sigs)
         )
 
-        if background_sigs != 0:
+        if background_sigs and len(background_sigs) > 0:
             background_sig_idx = get_indeces(allsigids, ["SBS1", "SBS5"])
+        else:
+            background_sig_idx = []
 
         try:
             (

--- a/SigProfilerAssignment/decomposition.py
+++ b/SigProfilerAssignment/decomposition.py
@@ -264,6 +264,7 @@ def spa_analyze(
     make_metadata=True,
     volume=None,
     cpu=-1,
+    add_background_signatures=True,
 ):
     """
     Decomposes the De Novo Signatures into COSMIC Signatures and assigns COSMIC signatures into samples.
@@ -644,7 +645,10 @@ def spa_analyze(
             attribution[i] = [i]
         # only for SBS96
         if mutation_type == "96" or mutation_type == "288" or mutation_type == "1536":
-            background_sigs = sub.get_indeces(list(allsigids), ["SBS1", "SBS5"])
+            if add_background_signatures:
+                background_sigs = sub.get_indeces(list(allsigids), ["SBS1", "SBS5"])
+            else:
+                background_sigs = []
             # add connected signatures
             # different_signatures = ss.add_connected_sigs(different_signatures, list(signames))
         # for other contexts
@@ -855,6 +859,7 @@ def spa_analyze(
             exome=exome,
             m_for_subgroups=m_for_subgroups,
             volume=volume,
+            add_background_signatures=add_background_signatures,
         )
         # final_signatures = sub.signature_decomposition(processAvg, m, layer_directory2, genome_build=genome_build)
         # extract the global signatures and new signatures from the final_signatures dictionary
@@ -1016,7 +1021,10 @@ def spa_analyze(
             attribution[i] = [i]
         # only for SBS96
         if mutation_type == "96" or mutation_type == "288" or mutation_type == "1536":
-            background_sigs = sub.get_indeces(list(allsigids), ["SBS1", "SBS5"])
+            if add_background_signatures:
+                background_sigs = sub.get_indeces(list(allsigids), ["SBS1", "SBS5"])
+            else:
+                background_sigs = []
             # add connected signatures
             # different_signatures = ss.add_connected_sigs(different_signatures, list(signames))
         # for other contexts


### PR DESCRIPTION
Add add_background_signatures parameter (default: True) to allow users to disable the automatic inclusion of background signatures SBS1 and SBS5 during signature assignment.

- Added parameter to spa_analyze(), signature_decomposition(), and all Analyzer functions
- Added CLI flag --add_background_signatures
- Updated logic to conditionally add SBS1/SBS5 only when enabled
- Maintains backward compatibility (defaults to True)