### PR TITLE
v1.0.3: Add parameter to toggle automatic background signature addition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,19 +46,24 @@ after_success:
       REPO_NAME=$(basename $TRAVIS_REPO_SLUG | tr '[:upper:]' '[:lower:]')
       IMAGE_NAME="ghcr.io/alexandrovlab/$REPO_NAME"
 
-      echo "Building version: $VERSION_TAG for image: $IMAGE_NAME"
-
+      echo "Checking if $IMAGE_NAME:$VERSION_TAG already exists on GHCR..."
       echo "$GHCR_PASSWORD" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin
 
-      docker build \
-        --build-arg COMMIT_SHA=$TRAVIS_COMMIT \
-        -t $IMAGE_NAME:$VERSION_TAG \
-        -t $IMAGE_NAME:latest .
+      if docker manifest inspect $IMAGE_NAME:$VERSION_TAG > /dev/null 2>&1; then
+        echo "Tag $IMAGE_NAME:$VERSION_TAG already exists. Skipping Docker push."
+      else
+        echo "Building version: $VERSION_TAG for image: $IMAGE_NAME"
 
-      docker push $IMAGE_NAME:$VERSION_TAG
-      docker push $IMAGE_NAME:latest
+        docker build \
+          --build-arg COMMIT_SHA=$TRAVIS_COMMIT \
+          -t $IMAGE_NAME:$VERSION_TAG \
+          -t $IMAGE_NAME:latest .
 
-      echo "Docker deployment to GHCR successful"
+        docker push $IMAGE_NAME:$VERSION_TAG
+        docker push $IMAGE_NAME:latest
+
+        echo "Docker deployment to GHCR successful"
+      fi
     else
       echo "Skipping Docker deployment"
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.0.3] - 2025-10-31
+### Added
+- Added `add_background_signatures` parameter (default: `True`) to control whether background signatures SBS1 and SBS5 are automatically added during signature assignment.
+- Parameter available in `spa_analyze()`, `signature_decomposition()`, and all Analyzer functions (`decompose_fit()`, `denovo_fit()`, `cosmic_fit()`).
+- CLI parameter `--add_background_signatures` added to match Python API functionality.
+- When set to `False`, background signatures are not forced but may still be detected naturally if present in samples.
+
+### Changed
+- Background signature assignment logic now respects the `add_background_signatures` parameter instead of always forcing SBS1/SBS5 inclusion.
+
 ## [1.0.2] - 2025-10-28
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 if os.path.exists("dist"):
     shutil.rmtree("dist")
 
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 
 
 def write_version_py(filename="SigProfilerAssignment/version.py"):
@@ -15,7 +15,7 @@ def write_version_py(filename="SigProfilerAssignment/version.py"):
 # THIS FILE IS GENERATED FROM SigProfilerAssignment SETUP.PY
 short_version = '%(version)s'
 version = '%(version)s'
-Update = 'v1.0.2: Add automated Docker build and publish pipeline'
+Update = 'v1.0.3: Add parameter to toggle automatic background signature addition'
 
     """
     fh = open(filename, "w")


### PR DESCRIPTION
Introduce `add_background_signatures` (default: True) to allow disabling the automatic inclusion of SBS1 and SBS5 during signature assignment.

- Added parameter to spa_analyze(), signature_decomposition(), and all Analyzer functions (decompose_fit, denovo_fit, cosmic_fit)
- Added CLI flag --add_background_signatures
- Updated logic to conditionally include SBS1/SBS5 only when enabled
- Fixed process_sample() to handle empty background signature lists

Maintains backward compatibility by defaulting to True.